### PR TITLE
Add slugs to post URL's

### DIFF
--- a/client/views/posts/modules/post_title.js
+++ b/client/views/posts/modules/post_title.js
@@ -1,6 +1,10 @@
 Template[getTemplate('postTitle')].helpers({
   postLink: function(){
-    return !!this.url ? getOutgoingUrl(this.url) : "/posts/"+this._id;
+    if (!!this.url) {
+      return getOutgoingUrl(this.url);
+    } else {
+      return getPostPageUrl(this);
+    }
   },
   postTarget: function() {
     return !!this.url ? '_blank' : '';

--- a/collections/posts.js
+++ b/collections/posts.js
@@ -140,7 +140,7 @@ getPostProperties = function(post) {
 };
 
 getPostPageUrl = function(post){
-  return getSiteUrl()+'posts/'+post._id;
+  return getSiteUrl()+'posts/'+post._id+"/p/"+slugifyPost(post.title);
 };
 
 getPostEditUrl = function(id){

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -55,9 +55,6 @@ getSignupUrl = function(){
 getSigninUrl = function(){
   return Meteor.absoluteUrl()+'sign-in';
 };
-getPostUrl = function(id){
-  return Meteor.absoluteUrl()+'posts/'+id;
-};
 getPostEditUrl = function(id){
   return Meteor.absoluteUrl()+'posts/'+id+'/edit';
 };
@@ -77,6 +74,14 @@ slugify = function(text) {
   }
   return text;
 };
+slugifyPost = function(title) {
+  if (title) {
+    return title.toLowerCase()
+                .replace(/[^-a-z0-9]/g, '-')
+                .substring(0, 140);
+  }
+  return '';
+}
 getShortUrl = function(post){
   return post.shortUrl ? post.shortUrl : post.url;
 };

--- a/lib/router.js
+++ b/lib/router.js
@@ -547,8 +547,20 @@ Meteor.startup(function () {
     // Post Page
 
     this.route('post_page', {
-      template: getTemplate('post_page'),
       path: '/posts/:_id',
+      controller: PostPageController,
+      action: function() {
+        var post = this.post();
+        Router.go("post_page_with_slug", {
+          _id: post._id,
+          slug: slugifyPost(post.title)
+        });
+      }
+    });
+
+    this.route('post_page_with_slug', {
+      path: '/posts/:_id/p/:slug?',
+      template: getTemplate('post_page'),
       controller: PostPageController
     });
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -554,7 +554,7 @@ Meteor.startup(function () {
         Router.go("post_page_with_slug", {
           _id: post._id,
           slug: slugifyPost(post.title)
-        });
+        }, {replaceState: true});
       }
     });
 

--- a/packages/telescope-rss/lib/server/rss.js
+++ b/packages/telescope-rss/lib/server/rss.js
@@ -17,7 +17,7 @@ servePostRSS = function() {
     var description = !!post.body ? post.body+'</br></br>' : '';
     feed.item({
      title: post.title,
-     description: description+'<a href="'+getPostUrl(post._id)+'">Discuss</a>',
+     description: description+'<a href="'+getPostPageUrl(post)+'">Discuss</a>',
      author: post.author,
      date: post.postedAt,
      url: getPostLink(post),


### PR DESCRIPTION
For SEO, it's nice to have the post title in the URL.  This PR changes the canonical route for a post to be:

    /posts/:_id/p/:slug

The "/p/" part is so that a post with slug "edit" doesn't conflict with ``/posts/:_id/edit``.  Routes to ``/posts/:_id`` redirect to include the slug; though the index pages at least are updated to point directly to the slugified versions.