### PR TITLE
Invite bugfixes

### DIFF
--- a/client/views/users/user_item.js
+++ b/client/views/users/user_item.js
@@ -36,10 +36,11 @@ Template[getTemplate('user_item')].events({
   },
   'click .uninvite-link': function(e, instance){
     e.preventDefault();
-    Meteor.users.update(instance.data._id,{
-      $set:{
-        isInvited: false
-      }
+    var userId = instance.data._id;
+    var userEmail = getEmail(instance.data);
+    Meteor.call('uninviteUser', userId, userEmail, function(err, res) {
+      if (err)
+        throwError(err.reason);
     });
   },
   'click .admin-link': function(e, instance){

--- a/client/views/users/user_profile.js
+++ b/client/views/users/user_profile.js
@@ -78,8 +78,12 @@ Template[getTemplate('user_profile')].helpers({
 
 Template[getTemplate('user_profile')].events({
   'click .invite-link': function(e, instance){
-    Meteor.call('inviteUser', instance.data.user._id);
-    throwError('Thanks, user has been invited.');
+    Meteor.call('inviteUser', { userId: instance.data.user._id }, function(err, res) {
+      if (err)
+        throwError(err.reason);
+      else
+        throwError('Thanks, user has been invited.');
+    }); 
   },
   'click .posts-more': function (e) {
     e.preventDefault();


### PR DESCRIPTION
1. Inviting a user via their profile page did not work because the call
to ‘inviteUser’ did not include the userId key. Also it used to
previously show 'Thanks, user has been invited.' regardless of success or
failure.
2. Meteor.users.update( ... ) in inviteUser method had a
double $inc modifier meaning that inviteCount would never actually be
decreased.
3. Added a uninviteUser method. Previously uninviting a user from the
all-users admin page would just update that user’s isInvited flag to
false. This was a problem because if that user was invited again
it wouldn’t work because a invite would still exist for them in the
Invites collection. This new method removes them both.