### PR TITLE
Adding nav client unit test

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -80,7 +80,6 @@ telescope-post-by-feed
 # Testing
 
 sanjo:jasmine
-velocity:core
 velocity:html-reporter
 
 # Custom Packages

--- a/.meteor/packages
+++ b/.meteor/packages
@@ -77,4 +77,10 @@ telescope-singleday
 telescope-invites
 telescope-post-by-feed
 
+# Testing
+
+sanjo:jasmine
+velocity:core
+velocity:html-reporter
+
 # Custom Packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: node_js
-node_js:
-  - "0.10"
-before_install:
-  - "curl -L http://git.io/ejPSng | /bin/sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - "0.10"
+before_install:
+  - "curl -L http://git.io/ejPSng | /bin/sh"

--- a/client/views/nav/nav.js
+++ b/client/views/nav/nav.js
@@ -17,29 +17,11 @@ Template[getTemplate('nav')].helpers({
   getTemplate: function () {
     return getTemplate(this);
   },
-  userMenu: function () {
-    return getTemplate('userMenu');
-  },
   site_title: function(){
     return getSetting('title');
   },
   logo_url: function(){
     return getSetting('logoUrl');
-  },
-  logo_top: function(){
-    return Math.floor((70-getSetting('logoHeight'))/2);
-  },
-  logo_offset: function(){
-    return -Math.floor(getSetting('logoWidth')/2);
-  },
-  intercom: function(){
-    return !!getSetting('intercomId');
-  },
-  canPost: function(){
-    return canPost(Meteor.user());
-  },
-  requirePostsApproval: function(){
-    return getSetting('requirePostsApproval');
   }
 });
 

--- a/packages/telescope-theme-hubble/lib/client/scss/modules/_nav.scss
+++ b/packages/telescope-theme-hubble/lib/client/scss/modules/_nav.scss
@@ -71,15 +71,6 @@
 			color:white;
 			font-size:15px;
 			font-weight:normal;
-
-			&.intercom em{
-				&:before{
-					content:'(';
-				}
-				&:after{
-					content:')';
-				}
-			}
 		}
 	}
 }

--- a/tests/jasmine/client/unit/navSpec.js
+++ b/tests/jasmine/client/unit/navSpec.js
@@ -165,7 +165,7 @@ describe('test nav template', function() {
       expect(renderedSecondaryNav.length).toEqual(0);
     });
 
-    it('should render secondary nav directly after primary nav', function () {
+    var setupAndRenderNavs = function () {
       primaryNav = ['testPrimaryNavTemplate'];
       secondaryNav = ['testSecondaryNavTemplate'];
 
@@ -178,6 +178,10 @@ describe('test nav template', function() {
       );
 
       render();
+    };
+
+    it('should render secondary nav directly after primary nav', function () {
+      setupAndRenderNavs();
 
       var renderedPrimaryNav = $div.find('ul.nav.primary-nav');
       expect(renderedPrimaryNav.length).toEqual(1);
@@ -192,18 +196,7 @@ describe('test nav template', function() {
         return true;
       });
 
-      primaryNav = ['testPrimaryNavTemplate'];
-      secondaryNav = ['testSecondaryNavTemplate'];
-
-      var getNavContent = function (templateName) {
-        return templateName;
-      };
-      setupNavTemplatesWithSpies(
-        primaryNav.concat(secondaryNav),
-        getNavContent
-      );
-
-      render();
+      setupAndRenderNavs();
 
       var renderedPrimaryNav = $div.find('ul.nav.primary-nav.has-dropdown');
       expect(renderedPrimaryNav.length).toEqual(1);
@@ -216,18 +209,7 @@ describe('test nav template', function() {
         return false;
       });
 
-      primaryNav = ['testPrimaryNavTemplate'];
-      secondaryNav = ['testSecondaryNavTemplate'];
-
-      var getNavContent = function (templateName) {
-        return templateName;
-      };
-      setupNavTemplatesWithSpies(
-        primaryNav.concat(secondaryNav),
-        getNavContent
-      );
-
-      render();
+      setupAndRenderNavs();
 
       var renderedPrimaryNav = $div.find('ul.nav.primary-nav.no-dropdown');
       expect(renderedPrimaryNav.length).toEqual(1);

--- a/tests/jasmine/client/unit/navSpec.js
+++ b/tests/jasmine/client/unit/navSpec.js
@@ -1,0 +1,238 @@
+describe('test nav template', function() {
+  var $div;
+  // Setting layoutTemplate to null to avoid stubbing the template completely.
+  // Must happen here, because it will have otherwise run by the time beforeEach runs.
+  Router.configure({
+    layoutTemplate: null
+  });
+
+  beforeEach(function () {
+    $div = $('<div>');
+  });
+
+  var render = function () {
+    Blaze.render(Template[getTemplate('nav')], $div.get(0));
+  };
+
+  it('should render mobile menu button', function () {
+    render();
+
+    var mobileMenuButton = $div.find('a.mobile-only.mobile-menu-button');
+    expect(mobileMenuButton.length).toEqual(1);
+    expect(mobileMenuButton.attr('href')).toEqual('#menu');
+
+    expect(mobileMenuButton.find('svg').length).toEqual(1);
+  });
+
+  it('should render the logo from the setting', function () {
+    spyOn(window, 'getSetting').and.callFake(function (settingName) {
+      return settingName;
+    });
+
+    render();
+
+    var h1 = $div.find('h1.logo')
+    expect(h1.length).toEqual(1);
+    var link = h1.find('a');
+    expect(link.length).toEqual(1);
+    expect(link.attr('href')).toEqual('/');
+    expect(link.find('img').length).toEqual(1);
+    expect(link.find('img').attr('src')).toEqual('logoUrl');
+    expect(link.find('img').attr('alt')).toEqual('title');
+  });
+
+  it('should render the site title if logo_url setting is empty', function () {
+    spyOn(window, 'getSetting').and.callFake(function (settingName) {
+      if (settingName === 'logoUrl') {
+        return null;
+      }
+
+      return settingName;
+    });
+
+    render();
+
+    var h1 = $div.find('h1.logo')
+    expect(h1.length).toEqual(1);
+    var link = h1.find('a');
+    expect(link.length).toEqual(1);
+    expect(link.attr('href')).toEqual('/');
+    expect(link.find('img').length).toEqual(0);
+    expect(link.text()).toEqual('title');
+  });
+
+  describe('test primaryNav and secondaryNav', function () {
+    var globalPrimaryNav, globalSecondaryNav;
+
+    beforeEach(function () {
+      globalPrimaryNav = primaryNav;
+      primaryNav = [];
+      globalSecondaryNav = secondaryNav;
+      secondaryNav = [];
+    });
+
+    afterEach(function () {
+      primaryNav = globalPrimaryNav;
+      secondaryNav = globalSecondaryNav;
+    });
+
+    var setupNavTemplatesWithSpies = function (templateNames, renderFunction) {
+      var navSpies = {};
+
+      templateNames.forEach(function (templateName) {
+        Template[templateName] = new Blaze.Template(
+          templateName,
+          renderFunction.bind(null, templateName)
+        );
+        navSpies[templateName] = spyOn(Template[templateName], 'renderFunction').and.callThrough();
+      });
+
+      return navSpies;
+    };
+
+    var checkNavLisAndDeleteTemplates = function (renderedNav, templateNames, navSpies, contentFunction) {
+      var lis = renderedNav.find('li');
+      expect(lis.length).toEqual(templateNames.length);
+      // Check that each of the <li>s contains the expected content and that the corresponding
+      // renderFunction was called.
+      lis.each(function (index, el) {
+        var templateName = templateNames[index];
+        var navSpy = navSpies[templateName];
+        expect(navSpy.calls.count()).toEqual(1);
+        expect(el.innerHTML.trim()).toEqual(contentFunction(templateName));
+
+        // Cleanup test template
+        delete Template[templateName];
+      });
+    };
+
+    var testNav = function (templateNames, expectedSelector) {
+      var randomString = Math.random();
+
+      var getNavContent = function (templateName) {
+        return 'nav entry: ' + templateName + randomString;
+      };
+      var navSpies = setupNavTemplatesWithSpies(templateNames, getNavContent);
+
+      spyOn(window, 'getThemeSetting').and.callFake(function (settingName) {
+        return true;
+      });
+
+      render();
+
+      var renderedNav = $div.find(expectedSelector);
+      expect(renderedNav.length).toEqual(1);
+      // Check that dropdownClass was added
+      renderedNav.hasClass('has-dropdown');
+
+      checkNavLisAndDeleteTemplates(
+        renderedNav,
+        templateNames,
+        navSpies,
+        getNavContent
+      );
+    };
+
+    it('should render primary nav from global primaryNav array of template names', function () {
+      primaryNav = ['testNavTemplate1', 'testNavTemplate2'];
+
+      testNav(primaryNav, 'ul.nav.primary-nav.desktop-nav');
+    });
+
+    it('should not render primary nav if global primaryNav array is empty', function () {
+      primaryNav = [];
+
+      render();
+
+      // Look for broad selector just to make sure no .primary-nav exists
+      var renderedPrimaryNav = $div.find('.primary-nav');
+      expect(renderedPrimaryNav.length).toEqual(0);
+    });
+
+    it('should render secondary nav from global secondaryNav array of template names', function () {
+      secondaryNav = ['testNavTemplate1', 'testNavTemplate2'];
+
+      testNav(secondaryNav, 'ul.nav.secondary-nav.desktop-nav');
+    });
+
+    it('should not render secondary nav if global secondaryNav array is empty', function () {
+      secondaryNav = [];
+
+      render();
+
+      // Look for broad selector just to make sure no .secondary-nav exists
+      var renderedSecondaryNav = $div.find('.secondary-nav');
+      expect(renderedSecondaryNav.length).toEqual(0);
+    });
+
+    it('should render secondary nav directly after primary nav', function () {
+      primaryNav = ['testPrimaryNavTemplate'];
+      secondaryNav = ['testSecondaryNavTemplate'];
+
+      var getNavContent = function (templateName) {
+        return templateName;
+      };
+      setupNavTemplatesWithSpies(
+        primaryNav.concat(secondaryNav),
+        getNavContent
+      );
+
+      render();
+
+      var renderedPrimaryNav = $div.find('ul.nav.primary-nav');
+      expect(renderedPrimaryNav.length).toEqual(1);
+      var renderedSecondaryNav = $div.find('ul.nav.secondary-nav');
+      expect(renderedSecondaryNav.length).toEqual(1);
+
+      expect(renderedPrimaryNav.next()).toEqual(renderedSecondaryNav);
+    });
+
+    it('should have "has-dropdown" class if useDropdowns theme setting is true', function () {
+      spyOn(window, 'getThemeSetting').and.callFake(function (settingName) {
+        return true;
+      });
+
+      primaryNav = ['testPrimaryNavTemplate'];
+      secondaryNav = ['testSecondaryNavTemplate'];
+
+      var getNavContent = function (templateName) {
+        return templateName;
+      };
+      setupNavTemplatesWithSpies(
+        primaryNav.concat(secondaryNav),
+        getNavContent
+      );
+
+      render();
+
+      var renderedPrimaryNav = $div.find('ul.nav.primary-nav.has-dropdown');
+      expect(renderedPrimaryNav.length).toEqual(1);
+      var renderedSecondaryNav = $div.find('ul.nav.secondary-nav.has-dropdown');
+      expect(renderedSecondaryNav.length).toEqual(1);
+    });
+
+    it('should have "no-dropdown" class if useDropdowns theme setting is true', function () {
+      spyOn(window, 'getThemeSetting').and.callFake(function (settingName) {
+        return false;
+      });
+
+      primaryNav = ['testPrimaryNavTemplate'];
+      secondaryNav = ['testSecondaryNavTemplate'];
+
+      var getNavContent = function (templateName) {
+        return templateName;
+      };
+      setupNavTemplatesWithSpies(
+        primaryNav.concat(secondaryNav),
+        getNavContent
+      );
+
+      render();
+
+      var renderedPrimaryNav = $div.find('ul.nav.primary-nav.no-dropdown');
+      expect(renderedPrimaryNav.length).toEqual(1);
+      var renderedSecondaryNav = $div.find('ul.nav.secondary-nav.no-dropdown');
+      expect(renderedSecondaryNav.length).toEqual(1);
+    });
+  });
+});


### PR DESCRIPTION
Using the jasmine package seemed like the best way to go because we'll want most of the testing modes. I added the travis file, but it doesn't quite work yet (see https://travis-ci.org/anthonymayer/Telescope). I don't think any other changes should be required of the travis file right now though because I'm controlling it all through https://github.com/anthonymayer/travis-ci-meteor-packages. Once I get that working I'll probably add a tag in the README too.

Mostly I'm looking for feedback on testing structure. I'm hoping that after we have a few more examples of these that we start making adding/updating tests a requirement of push requests. Getting feedback from either @sanjo and/or @samhatoum would be awesome too.

I also deleted some nav stuff that looked unused.