### PR TITLE
Changed Sign-up to Register

### DIFF
--- a/packages/telescope-getting-started/content/read_this_first.md
+++ b/packages/telescope-getting-started/content/read_this_first.md
@@ -8,7 +8,7 @@ To make your first run a bit easier, we've taken the liberty of preloading your 
 
 The first thing you'll need to do is create your account. Since this will be the first ever account created in this app, it will automatically be assigned admin rights, and you'll then be able to access Telescope's settings panel.
 
-Click the “Sign Up” link in the top menu and come back here once you're done!
+Click the “Register” link in the top menu and come back here once you're done!
 
 ### 2. Configuring Settings
 


### PR DESCRIPTION
When there's account set up yet, the navigation says Register instead of Sign-up. 

![screen shot 2015-01-27 at 15 49 35](https://cloud.githubusercontent.com/assets/5339758/5920317/1ffe684c-a63c-11e4-920f-d31133f3ea12.png)

I've just updated the 'Read this First' steps accordingly.
