### PR TITLE
Added category assignment to feeds

### DIFF
--- a/packages/telescope-post-by-feed/lib/client/routes.js
+++ b/packages/telescope-post-by-feed/lib/client/routes.js
@@ -15,7 +15,8 @@ Meteor.startup(function () {
     waitOn: function() {
       return [
         Meteor.subscribe('feeds'),
-        Meteor.subscribe('allUsersAdmin')
+        Meteor.subscribe('allUsersAdmin'),
+        Meteor.subscribe('categories')
       ];
     },
     template: getTemplate('feeds')

--- a/packages/telescope-post-by-feed/lib/feeds.js
+++ b/packages/telescope-post-by-feed/lib/feeds.js
@@ -18,6 +18,26 @@ var feedSchema = new SimpleSchema({
         return users;
       }
     }
+  },
+   categories: {
+    type: [String],
+    label: 'categories',
+    optional: true,
+    autoform: {
+      instructions: 'Posts will be assigned to this category.',
+      noselect: true,
+      editable: true,
+      options: function () {
+          var categories = Categories.find().map(function (category) {
+            return {
+              value: category._id,
+              label: category.name
+            }  
+        });
+        console.log('selected category'+categories)
+        return categories;
+      }
+    }
   }
 });
 

--- a/packages/telescope-post-by-feed/lib/server/fetch_feeds.js
+++ b/packages/telescope-post-by-feed/lib/server/fetch_feeds.js
@@ -33,7 +33,7 @@ var handleFeed = function(error, feed) {
       var post = {
         title: he.decode(item.title),
         url: item.link,
-        feedId: feed.id,
+        feedId: feedId,
         feedItemId: item.id,
         userId: userId,
         categories:categories

--- a/packages/telescope-post-by-feed/lib/server/fetch_feeds.js
+++ b/packages/telescope-post-by-feed/lib/server/fetch_feeds.js
@@ -11,7 +11,9 @@ var handleFeed = function(error, feed) {
 
   var feedItems = _.first(feed.items, 20); // limit feed to 20 items just in case
   var userId = this._parser._options.userId;
-
+  var feedId = this._parser._options.feedId;
+  var categories = this._parser._options.categories;
+ 
   clog('// Parsing RSS feed: '+ feed.title)
 
   var newItemsCount = 0;
@@ -33,7 +35,8 @@ var handleFeed = function(error, feed) {
         url: item.link,
         feedId: feed.id,
         feedItemId: item.id,
-        userId: userId
+        userId: userId,
+        categories:categories
       }
 
       if (item.description)
@@ -71,12 +74,14 @@ fetchFeeds = function() {
 
     // if feed doesn't specify a user, default to admin
     var userId = !!feed.userId ? feed.userId : getFirstAdminUser()._id;
-
+    var categories =feed.categories;
+    var feedId = feed._id;
+    
     try {
 
       content = HTTP.get(feed.url).content;
       var feedHandler = new htmlParser.FeedHandler(handleFeed);
-      var parser = new htmlParser.Parser(feedHandler, {xmlMode: true, userId: userId});
+      var parser = new htmlParser.Parser(feedHandler, {xmlMode: true, userId: userId, categories:categories, feedId:feedId});
       parser.write(content);
       parser.end();
 

--- a/packages/telescope-post-by-feed/package.js
+++ b/packages/telescope-post-by-feed/package.js
@@ -14,6 +14,7 @@ Package.onUse(function(api) {
 
   api.use([
     'telescope-base', 
+    'telescope-tags',
     'aldeed:simple-schema',
     'aldeed:autoform',
     'tap:i18n',


### PR DESCRIPTION
I added category assignment by adding a field to the schema. You can assign multiple categories to an rss feed. It should work aslo without any category created or assigned. Also the feedId is now assigned to the post.