### PR TITLE
Various accessibility fixes, mainly hiding unnecessary elements from scr...

### DIFF
--- a/client/views/comments/comment_item.html
+++ b/client/views/comments/comment_item.html
@@ -7,16 +7,16 @@
       <div class="comment-content">
         <div class="comment-actions {{#if upvoted}}upvoted{{else}}not-upvoted{{/if}} {{#if downvoted}}downvoted{{else}}not-downvoted{{/if}}">
           <a class="upvote" href="#">
-            <i class="icon-up"></i>
+            <i class="icon-up" aria-hidden="true"></i>
             <span>{{_ "upvote"}}</span>
           </a>
           <a class="downvote" href="#">
-            <i class="icon-down"></i>
+            <i class="icon-down" aria-hidden="true"></i>
             <span>{{_ "downvote"}}</span>
           </a>
         </div>
         <div class="comment-meta">
-          <div class="user-avatar avatar-medium">{{> avatar userId=userId shape="circle"}}</div>
+          <div class="user-avatar avatar-medium" aria-hidden="true">{{> avatar userId=userId shape="circle"}}</div>
           <a class="comment-username" href="{{profileUrl}}">{{authorName}}</a>
           <span class="comment-time">{{timeAgo ago}},</span>
           <span class="points">{{upvotes}}</span> <span class="unit">points </span>

--- a/client/views/comments/comment_list.html
+++ b/client/views/comments/comment_list.html
@@ -1,5 +1,5 @@
 <template name="comment_list">
-  <ul class="comments comment-list">
+  <ul class="comments comment-list" aria-live="polite">
     {{#each child_comments}}
       {{> UI.dynamic template=comment_item}}
     {{/each}}

--- a/client/views/comments/comment_reply.html
+++ b/client/views/comments/comment_reply.html
@@ -8,7 +8,7 @@
     {{/with}}
 
     {{#with comment}}
-      <ul class="selected-comment">
+      <ul class="selected-comment" aria-live="polite">
        {{> UI.dynamic template=comment_item}}
       </ul>
     {{/with}}

--- a/client/views/posts/modules/post_admin.html
+++ b/client/views/posts/modules/post_admin.html
@@ -1,6 +1,6 @@
 <template name="postAdmin">
   {{#if isAdmin}}
-    <div class="post-meta-item">
+    <div class="post-meta-item" aria-live="off">
       {{#if showApprove}}
         | <a href="#" class="approve-link goto-edit">{{_ "approve"}}</a>
       {{/if}}

--- a/client/views/posts/modules/post_avatars.html
+++ b/client/views/posts/modules/post_avatars.html
@@ -1,11 +1,11 @@
 <template name="postAvatars">
-  <a href="{{profileUrl userId}}" class="avatar-link avatar-small author-avatar">
+  <a href="{{profileUrl userId}}" class="avatar-link avatar-small author-avatar" aria-hidden="true">
     {{> avatar userId=userId shape="circle"}}
   </a>
   {{#if commenters}}
     <div class="post-commenters">
     {{#each commenters}}
-      <a href="{{profileUrl this}}" class="avatar-link avatar-small commenter-avatar">
+      <a href="{{profileUrl this}}" class="avatar-link avatar-small commenter-avatar" aria-hidden="true">
         {{> avatar userId=this shape="circle"}}
       </a>
     {{/each}}

--- a/client/views/posts/modules/post_discuss.html
+++ b/client/views/posts/modules/post_discuss.html
@@ -1,6 +1,7 @@
 <template name="postDiscuss">
   <a class="discuss-link go-to-comments action" href="/posts/{{_id}}" title="{{_ 'discuss'}}">
-    <i class="action-icon icon-comment"></i>
+    <i class="action-icon icon-comment" aria-hidden="true"></i>
     <span class="action-count">{{commentCount}}</span>
+    <span class="sr-only"> {{_ "comments"}}</span>
   </a>
 </template>

--- a/client/views/posts/modules/post_info.html
+++ b/client/views/posts/modules/post_info.html
@@ -1,5 +1,5 @@
 <template name="postInfo">
-  <div class="post-meta-item">
+  <div class="post-meta-item" aria-live="off">
     <span class="points">{{baseScore}}</span>
     <span class="unit">{{pointsUnitDisplayText}}</span>
     {{#if postedAt}}<span class="post-time">{{timeAgo postedAt}}</span>{{/if}}

--- a/client/views/posts/modules/post_rank.html
+++ b/client/views/posts/modules/post_rank.html
@@ -1,3 +1,3 @@
 <template name="postRank">
-  <div class="post-rank-inner"><span>{{oneBasedRank}}</span></div>
+  <div class="post-rank-inner" aria-live="off"><span>{{oneBasedRank}}</span></div>
 </template>

--- a/client/views/posts/modules/post_upvote.html
+++ b/client/views/posts/modules/post_upvote.html
@@ -1,11 +1,13 @@
 <template name="postUpvote">
   {{#if upvoted}}
     <span class="upvote-link voted action" title="{{_ "upvoted"}}">
-      <i class="icon-check action-icon"></i>
+      <i class="icon-check action-icon" aria-hidden></i>
+      <span class="sr-only">{{_ "upvoted"}}</span>
     </span>
   {{else}}
     <a class="upvote-link not-voted action" href="#" title="{{_ "upvote_"}}">
-      <i class="icon-up action-icon"></i>
+      <i class="icon-up action-icon" aria-hidden="true"></i>
+      <span class="sr-only">{{_ "upvote_"}}</span>
     </a>
   {{/if}}
 </template>

--- a/client/views/posts/post_list/posts_list.html
+++ b/client/views/posts/post_list/posts_list.html
@@ -1,7 +1,7 @@
 <template name="posts_list">
   <div class="posts-wrapper grid grid-module">
     {{> UI.dynamic template=postsListIncoming data=incoming}}
-    <div class="posts list {{postsLayout}}">
+    <div class="posts list {{postsLayout}}" aria-live="polite">
       {{#each postsCursor}}
         {{> UI.dynamic template=before_post_item}}
         {{> UI.dynamic template=post_item}}

--- a/client/views/users/profile/user_info.html
+++ b/client/views/users/profile/user_info.html
@@ -2,7 +2,7 @@
   <div class="user-profile grid grid-module">
     <table>
       <tr>
-        <td colspan="2">{{> avatar user=this size="large" shape="circle"}}</td>
+        <td colspan="2" aria-hidden="true">{{> avatar user=this size="large" shape="circle"}}</td>
       </tr>
       {{#if isAdmin}}
         <tr>

--- a/client/views/users/user_item.html
+++ b/client/views/users/user_item.html
@@ -1,6 +1,6 @@
 <template name="user_item">
 <tr class="user">
-	<td>{{> avatar user=this shape="circle"}}</td>
+	<td aria-hidden="true">{{> avatar user=this shape="circle"}}</td>
 	<td>
 		<a href="{{getProfileUrl}}">{{displayName}}</a>
 		<br/>

--- a/packages/telescope-embedly/lib/client/post_thumbnail.html
+++ b/packages/telescope-embedly/lib/client/post_thumbnail.html
@@ -1,8 +1,8 @@
 <template name="postThumbnail">
   {{#if thumbnailUrl}}
-    <div class="post-thumbnail">
+    <div class="post-thumbnail" aria-hidden="true">
       <a class="post-thumbnail-link {{playVideoClass}}" href="{{postLink}}" target="_blank">
-        <img class="post-thumbnail-image" src="{{thumbnailUrl}}" onerror="this.style.display='none';"/>
+        <img class="post-thumbnail-image" src="{{thumbnailUrl}}" onerror="this.style.display='none';" aria-hidden="true"/>
       </a>
     </div>
   {{/if}}


### PR DESCRIPTION
...een readers, adding screen-reader-only content and using live regions for real-time content.

Telescope sites have a bad UX for screen reader users. First there are the use of icons for upvoting and commenting with no text equivalent. I added sr-only spans with text descriptions of these, and aria-hidden to the icons since some of them have spoken descriptions which don't make much sense or add clutter (interestingly enough, comments have "upvote"/"downvote" as words but posts don't, fixing that minor inconsistency would eliminate the need for the sr-only span for posts.)

Next I added aria-hidden to all the avatar links, hiding them from screen readers. They seem to be followed up with links to the profiles themselves so they seem a bit redundant, and screen readers spoke the images as a string ID.

Finally I added aria-live="polite" to the posts and comments lists, plus a few aria-live="off" attributes where it made sense. This makes screen readers automatically read new posts/comments as they arrive, but hides unnecessary changes like the recalculation of scores every 30 seconds.

I likely did one or two additional minor things that I'm forgetting. There's more work to do still, but I'll likely discover what needs done in time, particularly as this code rolls out to the various Telescope sites I read and I experience the UX first-hand.