### PR TITLE
Calling analyticsRequest in onRun instead of onAfterAction

### DIFF
--- a/lib/router/filters.js
+++ b/lib/router/filters.js
@@ -166,7 +166,7 @@ Meteor.startup( function (){
 
     // Router.onAfterAction(filters.resetScroll, {except:['posts_top', 'posts_new', 'posts_best', 'posts_pending', 'posts_category', 'all-users']});
     Router.onAfterAction(analyticsInit); // will only run once thanks to _.once()
-    Router.onAfterAction(analyticsRequest); // log this request with mixpanel, etc
+    Router.onRun(analyticsRequest); // log this request with mixpanel, etc
     Router.onAfterAction(filters.setTitle);
 
     // Unload Hooks


### PR DESCRIPTION
onAfterAction can be called multiple times per route change, whereas onRun is only called once per page change