### PR TITLE
Mailchimp limits email subject to 150 characters

### DIFF
--- a/packages/telescope-newsletter/lib/server/mailchimp.js
+++ b/packages/telescope-newsletter/lib/server/mailchimp.js
@@ -8,16 +8,23 @@ scheduleCampaign = function (campaign, isTest) {
 
   if(!!apiKey && !!listId){
 
+		var wordCount = 15;
+		var subject = campaign.subject;
+		while (subject.length >= 150){
+			subject = trimWords(subject, wordCount);
+			wordCount--;
+		}
+		
     try {
 
       var api = new MailChimp(apiKey);
       var text = htmlToText.fromString(campaign.html, {wordwrap: 130});
-      var defaultEmail = getSetting('defaultEmail');
+      var defaultEmail = getSetting('defaultEmail');			
       var campaignOptions = {
         type: 'regular',
         options: {
           list_id: listId,
-          subject: campaign.subject,
+          subject: subject,
           from_email: defaultEmail,
           from_name: getSetting('title')+ ' Top Posts',
         },
@@ -56,14 +63,14 @@ scheduleCampaign = function (campaign, isTest) {
       var confirmationHtml = getEmailTemplate('emailDigestConfirmation')({
         time: scheduledTime,
         newsletterLink: campaign.archive_url,
-        subject: campaign.subject
+        subject: subject
       });
       sendEmail(defaultEmail, 'Newsletter scheduled', buildEmailTemplate(confirmationHtml));
 
     } catch (error) {
       console.log(error);
     }
-    return campaign.subject;
+    return subject;
   }
 }
 


### PR DESCRIPTION
Campaign.js trims the newsletter's subject to 15 words which is enough in most cases. Yet, I have had the case where 15 words are more than 150 characters and the Mailchimp campaign fails.