### PR TITLE
extraCode helper in layout template was not defined

### DIFF
--- a/History.md
+++ b/History.md
@@ -4,6 +4,10 @@
 * Added setting for external fonts.
 * Use site tagline as homepage title.
 * Make favicon customizable.
+* Making webfont customizable. To get previous font back, use: `https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700,400italic,700italic`.
+* Fix juice issue.
+* Non-admins should not be able to access rejected posts.
+* Bulgarian translation (thanks @durrrr91!)
 
 ## v0.14.1 “TaglineScope”
 

--- a/client/views/common/layout.js
+++ b/client/views/common/layout.js
@@ -20,6 +20,9 @@ Template[getTemplate('layout')].helpers({
   css: function () {
     return getTemplate('css');
   },
+  extraCode: function() {
+    return getSetting('extraCode');
+  },
   heroModules: function () {
     return heroModules;
   },

--- a/i18n/en.i18n.json
+++ b/i18n/en.i18n.json
@@ -21,6 +21,7 @@
 
   // Settings Schema
   "title": "Title",
+  "description": "Description",
   "siteUrl": "Site URL",
   "tagline": "Tagline",
   "requireViewInvite": "Require Invite to View",
@@ -56,6 +57,8 @@
   "fontFamily": "Font Family",
   "authMethods": "Authentication Methods",
   "faviconUrl": "Favicon URL",
+  "mailURL": "MailURL",
+  "postsLayout": "Posts Layout",
   
   // Settings Fieldsets
   "general": "General",

--- a/lib/version.js
+++ b/lib/version.js
@@ -1,1 +1,1 @@
-telescopeVersion = "0.14.1";
+telescopeVersion = "0.14.2";

--- a/packages/telescope-embedly/i18n/en.i18n.json
+++ b/packages/telescope-embedly/i18n/en.i18n.json
@@ -3,5 +3,8 @@
   "thumbnailUrl": "Thumbnail",
   "regenerate_thumbnail": "Regenerate Thumbnail",
   "clear_thumbnail": "Clear Thumbnail",
-  "please_fill_in_embedly_key": "Please fill in your Embedly API key to enable thumbnails."
+  "please_fill_in_embedly_key": "Please fill in your Embedly API key to enable thumbnails.",
+  "embedlyKey": "Embedly API Key",
+  "thumbnailWidth": "Thumbnail Width",
+  "thumbnailHeight": "Thumbnail Height"
 }

--- a/packages/telescope-kadira/i18n/en.i18n.json
+++ b/packages/telescope-kadira/i18n/en.i18n.json
@@ -1,0 +1,4 @@
+{
+  "kadiraAppId": "Kadira App ID",
+  "kadiraAppSecret": "Kadira App Secret"
+}

--- a/packages/telescope-kadira/package-tap.i18n
+++ b/packages/telescope-kadira/package-tap.i18n
@@ -1,0 +1,5 @@
+{
+  "translation_function_name": "__",
+  "helper_name": "_",
+  "namespace": "project"
+}

--- a/packages/telescope-kadira/package.js
+++ b/packages/telescope-kadira/package.js
@@ -7,20 +7,24 @@ Package.describe({
 Package.onUse(function (api) {
 
   api.use([
+    'templating',
     'telescope-lib', 
-    'telescope-base'
+    'telescope-base',
+    'tap:i18n',
+    'meteorhacks:kadira@2.17.2'
   ], ['client', 'server']);
 
-  api.use([
-    'meteorhacks:kadira@2.17.2'
-  ], ['server']);
-
   api.add_files([
+    'package-tap.i18n',
     'lib/kadira-settings.js'
   ], ['client', 'server']);
 
   api.add_files([
     'lib/server/kadira.js'
   ], ['server']);
+
+  api.add_files([
+    "i18n/en.i18n.json"
+  ], ["client", "server"]);
 
 });

--- a/packages/telescope-releases/lib/server/import_releases.js
+++ b/packages/telescope-releases/lib/server/import_releases.js
@@ -27,6 +27,7 @@ Meteor.startup(function () {
   importRelease('0.13.0');
   importRelease('0.14.0');
   importRelease('0.14.1');
+  importRelease('0.14.2');
   
   // if this is before the first run, mark all release notes as read to avoid showing them
   if (!Events.findOne({name: 'firstRun'})) {

--- a/packages/telescope-releases/package.js
+++ b/packages/telescope-releases/package.js
@@ -72,6 +72,7 @@ Package.onUse(function (api) {
   api.addFiles('releases/0.13.0.md', 'server', { isAsset: true });
   api.addFiles('releases/0.14.0.md', 'server', { isAsset: true });
   api.addFiles('releases/0.14.1.md', 'server', { isAsset: true });
+  api.addFiles('releases/0.14.2.md', 'server', { isAsset: true });
 
   // i18n languages (must come last)
 

--- a/packages/telescope-releases/releases/0.14.2.md
+++ b/packages/telescope-releases/releases/0.14.2.md
@@ -1,0 +1,10 @@
+### v0.14.2 “FaviconScope”
+
+* Added settings for auth methods.
+* Added setting for external fonts.
+* Use site tagline as homepage title.
+* Make favicon customizable.
+* Making webfont customizable. To get previous font back, use: `https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700,400italic,700italic`.
+* Fix juice issue.
+* Non-admins should not be able to access rejected posts.
+* Bulgarian translation (thanks @durrrr91!)


### PR DESCRIPTION
The `{{{extraCode}}}` helper [in the layout template][1] was not defined anywhere and was not outputting anything as a result.  This fixes that.


[1]: https://github.com/TelescopeJS/Telescope/blob/devel/client/views/common/layout.html#L18