### PR TITLE
extraCode helper in layout template was not defined

### DIFF
--- a/client/views/common/layout.js
+++ b/client/views/common/layout.js
@@ -20,6 +20,9 @@ Template[getTemplate('layout')].helpers({
   css: function () {
     return getTemplate('css');
   },
+  extraCode: function() {
+    return getSetting('extraCode');
+  },
   heroModules: function () {
     return heroModules;
   },


### PR DESCRIPTION
The `{{{extraCode}}}` helper [in the layout template][1] was not defined anywhere and was not outputting anything as a result.  This fixes that.


[1]: https://github.com/TelescopeJS/Telescope/blob/devel/client/views/common/layout.html#L18