### PR TITLE
Improved vote accessability for packages

### DIFF
--- a/lib/vote.js
+++ b/lib/vote.js
@@ -1,8 +1,10 @@
 
 // returns how much "power" a user's votes have
 var getVotePower = function (user) {
-  // return isAdmin(user) ? 5 : 1;
-  return 1; // for now, leave everybody at 1 including admins; 5 is too unbalanced
+  power = 1; 
+  if(typeof votePowerEq == 'function')
+    power = votePowerEq(user);
+  return power;
 };
 
 var modifyKarma = function (userId, karma) {

--- a/lib/vote.js
+++ b/lib/vote.js
@@ -178,6 +178,19 @@ cancelUpvote = function (collection, item, user) {
     // if the item is being upvoted by its own author, don't give karma
     if (item.userId != user._id)
       modifyKarma(item.userId, votePower);
+
+
+
+    // --------------------- Server-Side Async Callbacks --------------------- //
+
+    if (Meteor.isServer) {
+      Meteor.defer(function () { // use defer to avoid holding up client
+        // run all post submit server callbacks on post object successively
+        result = cancelUpvoteCallbacks.reduce(function(result, currentFunction) {
+            return currentFunction(collection, result, user);
+        }, result);
+      });
+    }
   }
   // console.log(collection.findOne(item._id));
   return true;
@@ -210,6 +223,19 @@ cancelDownvote = function (collection, item, user) {
     // if the item is being upvoted by its own author, don't give karma
     if (item.userId != user._id)
       modifyKarma(item.userId, votePower);
+
+
+
+    // --------------------- Server-Side Async Callbacks --------------------- //
+
+    if (Meteor.isServer) {
+      Meteor.defer(function () { // use defer to avoid holding up client
+        // run all post submit server callbacks on post object successively
+        result = cancelDownvoteCallbacks.reduce(function(result, currentFunction) {
+            return currentFunction(collection, result, user);
+        }, result);
+      });
+    }
   }
   // console.log(collection.findOne(item._id));
   return true;

--- a/lib/vote.js
+++ b/lib/vote.js
@@ -82,6 +82,13 @@ upvoteItem = function (collection, item, user) {
       }
     }
 
+      // ------------------------------ Callbacks ------------------------------ //
+
+    // run all post submit server callbacks on post object successively
+    result = upvoteMethodCallbacks.reduce(function(result, currentFunction) {
+      return currentFunction(collection, result, user);
+    }, item);
+
     // --------------------- Server-Side Async Callbacks --------------------- //
 
     if (Meteor.isServer) {
@@ -135,6 +142,14 @@ downvoteItem = function (collection, item, user) {
       modifyKarma(item.userId, votePower);
 
 
+      // ------------------------------ Callbacks ------------------------------ //
+
+    // run all post submit server callbacks on post object successively
+    result = downvoteMethodCallbacks.reduce(function(result, currentFunction) {
+      return currentFunction(collection, result, user);
+    }, item);
+
+
     // --------------------- Server-Side Async Callbacks --------------------- //
 
     if (Meteor.isServer) {
@@ -181,6 +196,14 @@ cancelUpvote = function (collection, item, user) {
 
 
 
+      // ------------------------------ Callbacks ------------------------------ //
+
+    // run all post submit server callbacks on post object successively
+    result = cancelUpvoteMethodCallbacks.reduce(function(result, currentFunction) {
+      return currentFunction(collection, result, user);
+    }, item);
+
+
     // --------------------- Server-Side Async Callbacks --------------------- //
 
     if (Meteor.isServer) {
@@ -224,6 +247,14 @@ cancelDownvote = function (collection, item, user) {
     if (item.userId != user._id)
       modifyKarma(item.userId, votePower);
 
+
+
+      // ------------------------------ Callbacks ------------------------------ //
+
+    // run all post submit server callbacks on post object successively
+    result = cancelDownvoteMethodCallbacks.reduce(function(result, currentFunction) {
+      return currentFunction(collection, result, user);
+    }, item);
 
 
     // --------------------- Server-Side Async Callbacks --------------------- //

--- a/packages/telescope-base/lib/base.js
+++ b/packages/telescope-base/lib/base.js
@@ -278,6 +278,8 @@ userProfileCompleteChecks = [];
 
 upvoteCallbacks = [];
 downvoteCallbacks = [];
+cancelUpvoteCallbacks = [];
+cancelDownvoteCallbacks = [];
 
 // ------------------------------------- User Profiles -------------------------------- //
 

--- a/packages/telescope-base/lib/base.js
+++ b/packages/telescope-base/lib/base.js
@@ -280,6 +280,10 @@ upvoteCallbacks = [];
 downvoteCallbacks = [];
 cancelUpvoteCallbacks = [];
 cancelDownvoteCallbacks = [];
+upvoteMethodCallbacks = [];
+downvoteMethodCallbacks = [];
+cancelUpvoteMethodCallbacks = [];
+cancelDownvoteMethodCallbacks = [];
 
 // ------------------------------------- User Profiles -------------------------------- //
 

--- a/packages/telescope-base/lib/base.js
+++ b/packages/telescope-base/lib/base.js
@@ -343,3 +343,8 @@ themeSettings = {
 
 // array containing subscriptions to be preloaded
 preloadSubscriptions = [];
+
+// ------------------------------- Vote Power -------------------------------- //
+
+// The equation to determine Vote Power
+votePowerEq = null;

--- a/packages/telescope-base/package.js
+++ b/packages/telescope-base/package.js
@@ -79,6 +79,8 @@ Package.onUse(function (api) {
     'getTemplate',
     'templates',
 
-    'themeSettings'
+    'themeSettings',
+
+    'votePowerEq'
     ]);
 });

--- a/packages/telescope-base/package.js
+++ b/packages/telescope-base/package.js
@@ -64,6 +64,10 @@ Package.onUse(function (api) {
     'downvoteCallbacks',
     'cancelUpvoteCallbacks',
     'cancelDownvoteCallbacks',
+    'upvoteMethodCallbacks',
+    'downvoteMethodCallbacks',
+    'cancelUpvoteMethodCallbacks',
+    'cancelDownvoteMethodCallbacks',
     
     'userEditRenderedCallbacks',
     'userEditClientCallbacks',

--- a/packages/telescope-base/package.js
+++ b/packages/telescope-base/package.js
@@ -62,6 +62,8 @@ Package.onUse(function (api) {
 
     'upvoteCallbacks',
     'downvoteCallbacks',
+    'cancelUpvoteCallbacks',
+    'cancelDownvoteCallbacks',
     
     'userEditRenderedCallbacks',
     'userEditClientCallbacks',


### PR DESCRIPTION
This is a modification which adds various callback hooks for the voting system.

It adds the callbacks:
<pre><code>cancelUpvoteCallbacks
cancelDownvoteCallbacks
upvoteMethodCallbacks
downvoteMethodCallbacks
cancelUpvoteMethodCallbacks
cancelDownvoteMethodCallbacks
</code></pre>
To the existing callbacks of:
<pre><code>upvoteCallbacks
downvoteCallbacks
</code></pre>

The advantage of the Method callbacks over the original ones is that the original ones ran asynchronously server-side, wheras the Method callbacks will hold up the vote action until the code in the callbacks finishes, which may be useful in some cases, and they run on both the server and client.

The original names were left consistent for backwards compatibility, but it may be worth considering changing the names to something that makes more sense, like upvoteServerCallbacks or upvoteAsyncCallbacks.


The other modification is a hook which allows for one to set an equation which will determine the power of a vote from within a package. This is done by, within the package, setting votePowerEq equal to a function which returns the value, such as this:
<pre><code>votePowerEq = function (user) {
  var power = user.karma/10 + 1;
  if(isAdmin(user)){
    power *= 2;
  }
  return Math.round(power);
};
</code></pre>

Then the package must re-export votePowerEq. It's worth noting that the last package to load will be the one that has the equation chosen, if there are multiple ones, but really you should be designing your packages modularly enough that you should be able to remove the package which is conflicting with the one you want to work. If a function is not defined, then the vote power defaults to one. This can be changed from within the vote.js code easily.