### PR TITLE
Correct base score calculation in vote.js

### DIFF
--- a/lib/vote.js
+++ b/lib/vote.js
@@ -147,7 +147,7 @@ downvoteItem = function (collection, item, user) {
     addVote(user._id, vote, collectionName, 'down');
 
     // extend item with baseScore to help calculate newScore
-    item = _.extend(item, {baseScore: (item.baseScore + votePower)});
+    item = _.extend(item, {baseScore: (item.baseScore - votePower)});
     updateScore({collection: collection, item: item, forceUpdate: true});
 
     // if the item is being upvoted by its own author, don't give karma
@@ -201,7 +201,7 @@ cancelUpvote = function (collection, item, user) {
     removeVote(user._id, item._id, collectionName, 'up');
 
     // extend item with baseScore to help calculate newScore
-    item = _.extend(item, {baseScore: (item.baseScore + votePower)});
+    item = _.extend(item, {baseScore: (item.baseScore - votePower)});
     updateScore({collection: collection, item: item, forceUpdate: true});
 
     // if the item is being upvoted by its own author, don't give karma


### PR DESCRIPTION
When we downvote an item or cancel one of its upvotes, we should decrese, not increase, the base score.