### PR TITLE
Refactor postAfterEditMethodCallbacks execution on server

### DIFF
--- a/collections/posts.js
+++ b/collections/posts.js
@@ -492,10 +492,10 @@ Meteor.methods({
 
     // ------------------------------ Callbacks ------------------------------ //
 
-    // run all post submit server callbacks on modifier object successively
-    modifier = postAfterEditMethodCallbacks.reduce(function(result, currentFunction) {
-        return currentFunction(result);
-    }, modifier);
+    // run all post after edit method callbacks successively
+    postAfterEditMethodCallbacks.forEach(function(currentFunction) {
+      currentFunction(modifier, postId);
+    });
 
     // ------------------------------ After Update ------------------------------ //
 
@@ -557,7 +557,7 @@ Meteor.methods({
       Posts.update(postId, { $inc: { viewCount: 1 }});
     }
   },
-  
+
   deletePostById: function(postId) {
     // remove post comments
     // if(!this.isSimulation) {


### PR DESCRIPTION
postAfterEditMethodCallbacks execution behaviour was copied straight away from postEditMethodCallbacks execution : perform a reduction on the post modifier by executing every callbacks.
Since postAfterEditMethodCallbacks is executed after the actual DB update, we don't need to alter the modifier because it won't be used, so we can use a plain forEach instead of a reduction.
We also need to pass the post ID to the callback (as second argument so it won't break existing callbacks) because there's no way to identify the post that was modified in the callback if we don't.

Other modification on line 560 is due to trailing whitespace auto removal in my code editor.