### PR TITLE
Server-side rendering package ?

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -88,3 +88,4 @@ telescope-subscribe-to-posts
 telescope-tagline-banner
 
 # Custom Packages
+telescope-ssr

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -72,6 +72,7 @@ meteorhacks:kadira@2.18.3
 meteorhacks:meteorx@1.3.1
 meteorhacks:npm@1.2.2
 meteorhacks:picker@1.0.1
+meteorhacks:ssr@2.1.1
 meteorhacks:subs-manager@1.3.0
 minifiers@1.1.3
 minimongo@1.0.6
@@ -130,6 +131,7 @@ telescope-releases@0.1.0
 telescope-rss@0.0.0
 telescope-search@0.0.0
 telescope-singleday@0.1.0
+telescope-ssr@0.0.1
 telescope-subscribe-to-posts@0.1.0
 telescope-tagline-banner@0.1.0
 telescope-tags@0.0.0

--- a/packages/telescope-ssr/package.js
+++ b/packages/telescope-ssr/package.js
@@ -1,0 +1,44 @@
+Package.describe({
+	summary: "Server-side rendering for Telescope (alpha)",
+	version: "0.0.1"
+});
+
+Package.onUse(function(api) {
+	api.versionsFrom("METEOR@1.0.3.2");
+	//
+	api.use("webapp","server");
+	//
+	api.use([
+		"sacha:juice@0.1.2",
+		"meteorhacks:ssr@2.1.1"
+	],"server");
+	// private
+	api.addFiles([
+		"private/views/common/css.html",
+		"private/views/common/layout.html",
+		"private/views/common/open-graph.html",
+		"private/views/common/twitter-card.html",
+		"private/views/nav/nav.html",
+		"private/views/posts/modules/post-content.html",
+		"private/views/posts/post-body.html",
+		"private/views/posts/post-item.html",
+		"private/views/posts/post-share-page.html",
+		"private/views/main.html"
+	], "server",{
+		isAsset:true
+	});
+	// server
+	api.addFiles([
+		"server/lib/ssr.js",
+		"server/views/common/css.js",
+		"server/views/common/layout.js",
+		"server/views/common/open-graph.js",
+		"server/views/common/twitter-card.js",
+		"server/views/nav/nav.js",
+		"server/views/posts/modules/post-content.js",
+		"server/views/posts/post-body.js",
+		"server/views/posts/post-item.js",
+		"server/views/posts/post-share-page.js",
+		"server/views/main.js"
+	], "server");
+});

--- a/packages/telescope-ssr/package.js
+++ b/packages/telescope-ssr/package.js
@@ -8,10 +8,7 @@ Package.onUse(function(api) {
 	//
 	api.use("webapp","server");
 	//
-	api.use([
-		"sacha:juice@0.1.2",
-		"meteorhacks:ssr@2.1.1"
-	],"server");
+	api.use("meteorhacks:ssr@2.1.1","server");
 	// private
 	api.addFiles([
 		"private/views/common/css.html",
@@ -19,7 +16,11 @@ Package.onUse(function(api) {
 		"private/views/common/open-graph.html",
 		"private/views/common/twitter-card.html",
 		"private/views/nav/nav.html",
+		"private/views/posts/modules/post-author.html",
+		"private/views/posts/modules/post-comments-link.html",
 		"private/views/posts/modules/post-content.html",
+		"private/views/posts/modules/post-domain.html",
+		"private/views/posts/modules/post-info.html",
 		"private/views/posts/post-body.html",
 		"private/views/posts/post-item.html",
 		"private/views/posts/post-share-page.html",
@@ -35,7 +36,11 @@ Package.onUse(function(api) {
 		"server/views/common/open-graph.js",
 		"server/views/common/twitter-card.js",
 		"server/views/nav/nav.js",
+		"server/views/posts/modules/post-author.js",
+		"server/views/posts/modules/post-comments-link.js",
 		"server/views/posts/modules/post-content.js",
+		"server/views/posts/modules/post-domain.js",
+		"server/views/posts/modules/post-info.js",
 		"server/views/posts/post-body.js",
 		"server/views/posts/post-item.js",
 		"server/views/posts/post-share-page.js",

--- a/packages/telescope-ssr/private/views/common/css.html
+++ b/packages/telescope-ssr/private/views/common/css.html
@@ -1,0 +1,35 @@
+<style>
+  @import url({{getSetting "fontUrl"}});
+  body, textarea, input, button, input[type="submit"], input[type="button"]{
+    font-family: {{getSetting "fontFamily"}};
+  }
+  body{
+    background: {{getSetting "backgroundCSS"}};
+  }
+  .header{
+    background-color: {{getSetting "headerColor"}} !important;
+  }
+  .header, .header .logo a, .header .logo a:visited{
+    color: {{getSetting "headerTextColor"}};
+  }
+  input[type="submit"], button, .button, button.submit, .auth-buttons #login-buttons #login-buttons-password, .btn-primary, .header .btn-primary, .header .btn-primary:link, .header .btn-primary:visited, .error, .mobile-menu-button, .login-link-text, .post-category:hover{
+    background-color: {{getSetting "buttonColor"}};
+    color: {{getSetting "buttonTextColor"}};
+  }
+  a:hover, .post-content .post-heading .post-title:hover, .post-content .post-upvote .upvote-link i, .comment-actions a i, .comment-actions.upvoted .upvote i, .comment-actions.downvoted .downvote i, .toggle-actions-link, .post-meta a:hover, .action:hover, .post-upvote .upvote-link i{
+    color: {{getSetting "buttonColor"}};
+  }
+  .post-upvote .upvote-link i{
+    border-color: {{getSetting "buttonColor"}};
+  }
+  .toggle-actions-link{
+    border-color: {{getSetting "buttonColor"}};
+  }
+  .post-content .post-upvote .upvote-link.voted i.icon-check{
+    /*color: {{getSetting "secondaryColor"}};*/
+  }
+  .logo-image a{
+    max-height:{{getSetting "logoHeight"}}px;
+    max-width:{{getSetting "logoWidth"}}px;
+  }
+</style>

--- a/packages/telescope-ssr/private/views/common/css.html
+++ b/packages/telescope-ssr/private/views/common/css.html
@@ -32,4 +32,5 @@
     max-height:{{getSetting "logoHeight"}}px;
     max-width:{{getSetting "logoWidth"}}px;
   }
+  {{css}}
 </style>

--- a/packages/telescope-ssr/private/views/common/layout.html
+++ b/packages/telescope-ssr/private/views/common/layout.html
@@ -1,0 +1,9 @@
+{{> css}}
+<div class="outer-wrapper">
+  <div class="inner-wrapper template-{{pageName}}">
+    {{> nav}}
+    <div class="content-wrapper">
+      {{> Template.dynamic template=yield data=this}}
+    </div>
+  </div>
+</div>

--- a/packages/telescope-ssr/private/views/common/open-graph.html
+++ b/packages/telescope-ssr/private/views/common/open-graph.html
@@ -1,0 +1,7 @@
+<meta property="og:type" content="{{type}}">
+<meta property="og:url" content="{{url}}">
+<meta property="og:title" content="{{title}}">
+<meta property="og:description" content="{{description}}">
+<meta property="og:site_name" content="{{site_name}}">
+<meta property="og:image" content="{{image}}">
+<meta property="fb:app_id" content="1596712360573667">

--- a/packages/telescope-ssr/private/views/common/twitter-card.html
+++ b/packages/telescope-ssr/private/views/common/twitter-card.html
@@ -1,0 +1,6 @@
+<meta name="twitter:card" content="summary">
+<meta name="twitter:site" content="{{site}}">
+<meta name="twitter:title" content="{{title}}">
+<meta name="twitter:description" content="{{description}}">
+<meta name="twitter:image" content="{{image}}">
+<meta name="twitter:url" content="{{url}}">

--- a/packages/telescope-ssr/private/views/main.html
+++ b/packages/telescope-ssr/private/views/main.html
@@ -1,0 +1,15 @@
+{{{doctype}}}
+<html>
+  <head>
+    <title>{{title}}</title>
+    <meta name="viewport" content="initial-scale=1.0">
+    <link type="image/x-icon" rel="shortcut icon" href="{{faviconUrl}}">
+    <!-- OPEN GRAPH -->
+    {{> openGraph og}}
+    <!-- TWITTER CARD -->
+    {{> twitterCard twitter}}
+  </head>
+  <body>
+    {{> layout}}
+  </body>
+</html>

--- a/packages/telescope-ssr/private/views/nav/nav.html
+++ b/packages/telescope-ssr/private/views/nav/nav.html
@@ -1,0 +1,13 @@
+<header class="header {{headerClass}}">
+  {{#if logoUrl}}
+    <h1 class="logo logo-image header-module">
+      <a href="/">
+        <img src="{{logoUrl}}" alt="{{siteTitle}}"/>
+      </a>
+    </h1>
+  {{else}}
+    <h1 class="logo header-module">
+      <a href="/">{{siteTitle}}</a>
+    </h1>
+  {{/if}}
+</header>

--- a/packages/telescope-ssr/private/views/posts/modules/post-author.html
+++ b/packages/telescope-ssr/private/views/posts/modules/post-author.html
@@ -1,0 +1,1 @@
+<a class="post-author" href="{{profileUrl userId}}">{{displayName userId}}</a>

--- a/packages/telescope-ssr/private/views/posts/modules/post-comments-link.html
+++ b/packages/telescope-ssr/private/views/posts/modules/post-comments-link.html
@@ -1,0 +1,6 @@
+<div class="post-meta-item">
+  <a class="comments-link" href="/posts/{{_id}}">
+    <span class="comments-count">{{commentCount}}</span>
+    <span class="comments-action">{{_ "comments_"}}</span>
+  </a>
+</div>

--- a/packages/telescope-ssr/private/views/posts/modules/post-content.html
+++ b/packages/telescope-ssr/private/views/posts/modules/post-content.html
@@ -1,0 +1,11 @@
+<div class="post-thumbnail" style="display:inline-block;">
+  <a class="post-thumbnail-link" href="{{postLink}}">
+    <img class="post-thumbnail-image" src="{{thumbnailUrl}}">
+  </a>
+</div>
+<div class="post-info" style="display:inline-block;vertical-align:top;">
+  <h3 class="post-heading">
+    <a href="{{postLink}}" class="post-title">{{title}}</a>
+  </h3>
+  <a href="/posts/{{_id}}">Comment this post on {{siteTitle}}</a>
+</div>

--- a/packages/telescope-ssr/private/views/posts/modules/post-content.html
+++ b/packages/telescope-ssr/private/views/posts/modules/post-content.html
@@ -1,11 +1,16 @@
-<div class="post-thumbnail" style="display:inline-block;">
+<div class="post-thumbnail">
   <a class="post-thumbnail-link" href="{{postLink}}">
     <img class="post-thumbnail-image" src="{{thumbnailUrl}}">
   </a>
 </div>
-<div class="post-info" style="display:inline-block;vertical-align:top;">
+<div class="post-info">
   <h3 class="post-heading">
     <a href="{{postLink}}" class="post-title">{{title}}</a>
+    {{> postDomain}}
   </h3>
-  <a href="/posts/{{_id}}">Comment this post on {{siteTitle}}</a>
+  <div class="post-meta">
+    {{> postAuthor}}
+    {{> postInfo}}
+    {{> postCommentsLink}}
+  </div>
 </div>

--- a/packages/telescope-ssr/private/views/posts/modules/post-domain.html
+++ b/packages/telescope-ssr/private/views/posts/modules/post-domain.html
@@ -1,0 +1,3 @@
+{{#if url}}
+  <span class="post-domain">{{domain}}</span>
+{{/if}}

--- a/packages/telescope-ssr/private/views/posts/modules/post-info.html
+++ b/packages/telescope-ssr/private/views/posts/modules/post-info.html
@@ -1,0 +1,5 @@
+<div class="post-meta-item">
+  <span class="points">{{baseScore}}</span>
+  <span class="unit">{{pointsUnitDisplayText}}</span>
+  {{#if postedAt}}<span class="post-time">{{timeAgo postedAt}}</span>{{/if}}
+</div>

--- a/packages/telescope-ssr/private/views/posts/post-body.html
+++ b/packages/telescope-ssr/private/views/posts/post-body.html
@@ -1,0 +1,3 @@
+<div class="post-body markdown">
+  {{{htmlBody}}}
+</div>

--- a/packages/telescope-ssr/private/views/posts/post-item.html
+++ b/packages/telescope-ssr/private/views/posts/post-item.html
@@ -1,0 +1,5 @@
+<div class="post {{#if sticky}}sticky{{/if}}" id="{{_id}}">
+  <div class="post-content post-module">
+    {{> postContent}}
+  </div>
+</div>

--- a/packages/telescope-ssr/private/views/posts/post-share-page.html
+++ b/packages/telescope-ssr/private/views/posts/post-share-page.html
@@ -1,0 +1,6 @@
+<div class="single-post grid">
+  <div class="posts posts-list">
+    {{> postItem}}
+  </div>
+  {{> postBody}}
+</div>

--- a/packages/telescope-ssr/private/views/posts/post-share-page.html
+++ b/packages/telescope-ssr/private/views/posts/post-share-page.html
@@ -3,4 +3,7 @@
     {{> postItem}}
   </div>
   {{> postBody}}
+  <div class="grid-block">
+    <a href="/posts/{{_id}}">Comment this post on {{siteTitle}}</a>
+  </div>
 </div>

--- a/packages/telescope-ssr/server/lib/ssr.js
+++ b/packages/telescope-ssr/server/lib/ssr.js
@@ -1,0 +1,78 @@
+function openGraphMetaProperties(post,protocol){
+  protocol=protocol || "http";
+  //
+  if(post.thumbnailUrl.indexOf("//")===0){
+    post.thumbnailUrl=protocol+":"+post.thumbnailUrl;
+  }
+  return {
+    type:"article",
+    url:Router.routes.post_page.url(post)+"/share",
+    title:post.title,
+    description:post.body,
+    site_name:getSetting("title"),
+    image:post.thumbnailUrl
+  };
+}
+
+function twitterMetaProperties(post,protocol){
+  protocol=protocol || "http";
+  //
+  if(post.thumbnailUrl.indexOf("//")===0){
+    post.thumbnailUrl=protocol+":"+post.thumbnailUrl;
+  }
+  return {
+    site:getSetting("twitterAccount"),
+    title:post.title,
+    description:post.body,
+    image:post.thumbnailUrl,
+    url:Router.routes.post_page.url(post)+"/share"
+  };
+}
+
+var fs=Npm.require("fs");
+var fsReadFileSync=Meteor.wrapAsync(fs.readFile,fs);
+
+function addInlineCss(html){
+  var cssName = _.find(Object.keys(WebAppInternals.staticFiles), function (fileName) {
+    return /.css$/.test(fileName);
+  });
+  var cssPath = WebAppInternals.staticFiles[cssName].absolutePath;
+  var css = fsReadFileSync(cssPath,{
+    encoding: "utf8"
+  });
+  //
+  return juice(html,{
+    extraCss: css
+  });
+}
+
+function postSharePageHandler(req, res, next) {
+  var urlRegexp=/^\/posts\/(\w+)\/share\??/;
+  var matches=req.url.match(urlRegexp);
+  //
+  if(!matches){
+    next();
+    return;
+  }
+  //
+  var postId=matches?matches[1]:null;
+  var post=Posts.findOne(postId);
+  var protocol=req.headers["x-forwarded-proto"];
+  var dataContext=_.extend(post,{
+    og:openGraphMetaProperties(post,protocol),
+    twitter:twitterMetaProperties(post,protocol),
+    yield:"postSharePage"
+  });
+  //
+  res.writeHead(200, {
+    "Content-Type": "text/html; charset=UTF-8"
+  });
+  var html=SSR.render("main",dataContext);
+  var htmlWithInlineCss=addInlineCss(html);
+  res.end(htmlWithInlineCss);
+}
+
+WebApp.connectHandlers.stack.splice(1,0,{
+  route:"",
+  handle:postSharePageHandler
+});

--- a/packages/telescope-ssr/server/lib/ssr.js
+++ b/packages/telescope-ssr/server/lib/ssr.js
@@ -29,23 +29,6 @@ function twitterMetaProperties(post,protocol){
   };
 }
 
-var fs=Npm.require("fs");
-var fsReadFileSync=Meteor.wrapAsync(fs.readFile,fs);
-
-function addInlineCss(html){
-  var cssName = _.find(Object.keys(WebAppInternals.staticFiles), function (fileName) {
-    return /.css$/.test(fileName);
-  });
-  var cssPath = WebAppInternals.staticFiles[cssName].absolutePath;
-  var css = fsReadFileSync(cssPath,{
-    encoding: "utf8"
-  });
-  //
-  return juice(html,{
-    extraCss: css
-  });
-}
-
 function postSharePageHandler(req, res, next) {
   var urlRegexp=/^\/posts\/(\w+)\/share\??/;
   var matches=req.url.match(urlRegexp);
@@ -68,8 +51,7 @@ function postSharePageHandler(req, res, next) {
     "Content-Type": "text/html; charset=UTF-8"
   });
   var html=SSR.render("main",dataContext);
-  var htmlWithInlineCss=addInlineCss(html);
-  res.end(htmlWithInlineCss);
+  res.end(html);
 }
 
 WebApp.connectHandlers.stack.splice(1,0,{

--- a/packages/telescope-ssr/server/views/common/css.js
+++ b/packages/telescope-ssr/server/views/common/css.js
@@ -1,0 +1,7 @@
+SSR.compileTemplate("css",Assets.getText("private/views/common/css.html"));
+
+Template.css.helpers({
+  getSetting:function(key){
+    return getSetting(key);
+  }
+});

--- a/packages/telescope-ssr/server/views/common/css.js
+++ b/packages/telescope-ssr/server/views/common/css.js
@@ -1,7 +1,20 @@
 SSR.compileTemplate("css",Assets.getText("private/views/common/css.html"));
 
+var fs=Npm.require("fs");
+var fsReadFileSync=Meteor.wrapAsync(fs.readFile,fs);
+
 Template.css.helpers({
   getSetting:function(key){
     return getSetting(key);
+  },
+  css:function(){
+    var cssName = _.find(_.keys(WebAppInternals.staticFiles), function (fileName) {
+      return /.css$/.test(fileName);
+    });
+    var cssPath = WebAppInternals.staticFiles[cssName].absolutePath;
+    var css = fsReadFileSync(cssPath,{
+      encoding: "utf8"
+    });
+    return css;
   }
 });

--- a/packages/telescope-ssr/server/views/common/layout.js
+++ b/packages/telescope-ssr/server/views/common/layout.js
@@ -1,0 +1,7 @@
+SSR.compileTemplate("layout",Assets.getText("private/views/common/layout.html"));
+
+Template.layout.helpers({
+  /*pageName: function(){
+    return getCurrentTemplate();
+  }*/
+});

--- a/packages/telescope-ssr/server/views/common/open-graph.js
+++ b/packages/telescope-ssr/server/views/common/open-graph.js
@@ -1,0 +1,1 @@
+SSR.compileTemplate("openGraph",Assets.getText("private/views/common/open-graph.html"));

--- a/packages/telescope-ssr/server/views/common/twitter-card.js
+++ b/packages/telescope-ssr/server/views/common/twitter-card.js
@@ -1,0 +1,1 @@
+SSR.compileTemplate("twitterCard",Assets.getText("private/views/common/twitter-card.html"));

--- a/packages/telescope-ssr/server/views/main.js
+++ b/packages/telescope-ssr/server/views/main.js
@@ -1,0 +1,10 @@
+SSR.compileTemplate("main",Assets.getText("private/views/main.html"));
+
+Template.main.helpers({
+  doctype:function(){
+    return "<!DOCTYPE html>";
+  },
+  faviconUrl:function(){
+    return getSetting("faviconUrl", "/img/favicon.ico");
+  }
+});

--- a/packages/telescope-ssr/server/views/nav/nav.js
+++ b/packages/telescope-ssr/server/views/nav/nav.js
@@ -1,0 +1,14 @@
+SSR.compileTemplate("nav",Assets.getText("private/views/nav/nav.html"));
+
+Template.nav.helpers({
+  logoUrl:function(){
+    return getSetting("logoUrl");
+  },
+  siteTitle:function(){
+    return getSetting("title", "Telescope");
+  },
+  headerClass: function () {
+    var color = getSetting("headerColor");
+    return (color == "white" || color == "#fff" || color == "#ffffff") ? "white-background" : "";
+  }
+});

--- a/packages/telescope-ssr/server/views/posts/modules/post-author.js
+++ b/packages/telescope-ssr/server/views/posts/modules/post-author.js
@@ -1,0 +1,10 @@
+SSR.compileTemplate("postAuthor",Assets.getText("private/views/posts/modules/post-author.html"));
+
+Template.postAuthor.helpers({
+  profileUrl:function(userId){
+    return getProfileUrlBySlugOrId(userId);
+  },
+  displayName:function(userId){
+    return getDisplayNameById(userId);
+  }
+});

--- a/packages/telescope-ssr/server/views/posts/modules/post-comments-link.js
+++ b/packages/telescope-ssr/server/views/posts/modules/post-comments-link.js
@@ -1,0 +1,7 @@
+SSR.compileTemplate("postCommentsLink",Assets.getText("private/views/posts/modules/post-comments-link.html"));
+
+Template.postCommentsLink.helpers({
+  _:function(key){
+    return i18n.t(key);
+  }
+});

--- a/packages/telescope-ssr/server/views/posts/modules/post-content.js
+++ b/packages/telescope-ssr/server/views/posts/modules/post-content.js
@@ -1,0 +1,10 @@
+SSR.compileTemplate("postContent",Assets.getText("private/views/posts/modules/post-content.html"));
+
+Template.postContent.helpers({
+  siteTitle:function(){
+    return getSetting("title");
+  },
+  postLink:function(){
+    return this.url ? getOutgoingUrl(this.url) : Router.routes.post_page.url(this);
+  }
+});

--- a/packages/telescope-ssr/server/views/posts/modules/post-content.js
+++ b/packages/telescope-ssr/server/views/posts/modules/post-content.js
@@ -1,9 +1,6 @@
 SSR.compileTemplate("postContent",Assets.getText("private/views/posts/modules/post-content.html"));
 
 Template.postContent.helpers({
-  siteTitle:function(){
-    return getSetting("title");
-  },
   postLink:function(){
     return this.url ? getOutgoingUrl(this.url) : Router.routes.post_page.url(this);
   }

--- a/packages/telescope-ssr/server/views/posts/modules/post-domain.js
+++ b/packages/telescope-ssr/server/views/posts/modules/post-domain.js
@@ -1,0 +1,10 @@
+SSR.compileTemplate("postDomain",Assets.getText("private/views/posts/modules/post-domain.html"));
+
+var url=Npm.require("url");
+
+Template.postDomain.helpers({
+  domain:function(){
+    var parsedUrl=url.parse(this.url);
+    return parsedUrl.hostname;
+  }
+});

--- a/packages/telescope-ssr/server/views/posts/modules/post-info.js
+++ b/packages/telescope-ssr/server/views/posts/modules/post-info.js
@@ -1,0 +1,10 @@
+SSR.compileTemplate("postInfo",Assets.getText("private/views/posts/modules/post-info.html"));
+
+Template.postInfo.helpers({
+  pointsUnitDisplayText: function(){
+    return this.upvotes == 1 ? i18n.t("point") : i18n.t("points");
+  },
+  timeAgo:function(datetime){
+    return moment(datetime).fromNow();
+  }
+});

--- a/packages/telescope-ssr/server/views/posts/post-body.js
+++ b/packages/telescope-ssr/server/views/posts/post-body.js
@@ -1,0 +1,1 @@
+SSR.compileTemplate("postBody",Assets.getText("private/views/posts/post-body.html"));

--- a/packages/telescope-ssr/server/views/posts/post-item.js
+++ b/packages/telescope-ssr/server/views/posts/post-item.js
@@ -1,0 +1,1 @@
+SSR.compileTemplate("postItem",Assets.getText("private/views/posts/post-item.html"));

--- a/packages/telescope-ssr/server/views/posts/post-share-page.js
+++ b/packages/telescope-ssr/server/views/posts/post-share-page.js
@@ -1,1 +1,7 @@
 SSR.compileTemplate("postSharePage",Assets.getText("private/views/posts/post-share-page.html"));
+
+Template.postSharePage.helpers({
+  siteTitle:function(){
+    return getSetting("title");
+  }
+});

--- a/packages/telescope-ssr/server/views/posts/post-share-page.js
+++ b/packages/telescope-ssr/server/views/posts/post-share-page.js
@@ -1,0 +1,1 @@
+SSR.compileTemplate("postSharePage",Assets.getText("private/views/posts/post-share-page.html"));


### PR DESCRIPTION
Hi there,

Here is my WIP proposal for addressing SSR in Telescope, everything is put inside a new telescope-ssr package.
I built this POC to drastically improve server response time for social sharing spiders, especially twitterbot who has a low timeout (4 seconds), making twitter cards virtually impossible to achieve if we were to rely on standard spiderable solution.
This package creates a new server route /posts/:_id/share, in the future we might want to use the regular post URL but then we have to make sure we generate the same HTML as Blaze does on the client, or else this could be considered cloaking (generating different content for spiders and regular browsers) which is penalized by SEO.

Generating the same HTML output for both server and client environment is painful as you can see by reading the code of this package.
Maybe we can improve the spiderable solution by using PhantomJS 2 and caching the generated HTML (I wasn't able to make spiderable-cached work for some reason), then we might not need SSR.

This PR is not supposed to be merged, it's just to open a discussion about Telescope and SSR.
Waiting to hear your input on this.

There is a live implementation on this website : http://www.gadgethunt.club/

Regards,