### PR TITLE
fix bug where last character in search keyword couldn't be cleared

### DIFF
--- a/packages/telescope-search/lib/client/routes.js
+++ b/packages/telescope-search/lib/client/routes.js
@@ -5,7 +5,13 @@ Meteor.startup(function () {
     onBeforeAction: function() {
       var query = this.params.query;
       if ('q' in query) {
-        Session.set('searchQuery', query.q);
+        // if search box has 'empty' class, that means user just deleted last character in search keyword
+        // but router hasn't updated url, so params.query still has '?q=<LAST CHARACTER>'
+        // if we set searchQuery in this case, user will see last character pops up again unexpectedly
+        // so add this check to fix the bug. issue #825
+        if (!$('.search').hasClass('empty'))  {
+          Session.set('searchQuery', query.q);
+        }
         if (query.q) {
           Meteor.call('logSearch', query.q)
         }


### PR DESCRIPTION
This fixes the bug in issue #825. User couldn't clear last character in search keyword because routes.js automatically sets it to be query string. We should check if user tries to clear last character before set searchQuery in Session.