### PR TITLE
Workaround categories permission and data type bug

### DIFF
--- a/collections/posts.js
+++ b/collections/posts.js
@@ -471,6 +471,12 @@ Meteor.methods({
         // loop over each property being operated on
         _.keys(operation).forEach(function (propertyName) {
           var property = postSchemaObject[propertyName];
+          // If we're handed an array index instead of a top-level property,
+          // try looking up by the parent array key.
+          if (!property) {
+            var parentKey = propertyName.split(/\.\d+/)[0];
+            property = postSchemaObject[parentKey];
+          }
           if (!property || !property.autoform || !property.autoform.editable) {
             console.log('//' + i18n.t('disallowed_property_detected') + ": " + propertyName);
             throw new Meteor.Error("disallowed_property", i18n.t('disallowed_property_detected') + ": " + propertyName);

--- a/packages/telescope-tags/lib/custom_fields.js
+++ b/packages/telescope-tags/lib/custom_fields.js
@@ -21,3 +21,29 @@ addToPostSchema.push(
     }
   }
 );
+
+/* Workaround for https://github.com/aldeed/meteor-autoform/issues/765 */
+postEditMethodCallbacks.push(function(modifier) {
+  // Force ''categories'' into an Array. AutoForm will send us an update that
+  // looks like:
+  //
+  // { $set: {
+  //    "categories.0": "<_id1>",
+  //    "categories.1": "<_id2>",
+  // }}
+  //
+  // which mongo treats as creating an object rather than an array.  Convert that into
+  //
+  // { $set: { categories: ["<_id1>", "<_id2>"] }}
+  var categoryIds = [];
+  _.each(modifier.$set, function(val, key) {
+    if (/categories\.\d+/.test(key)) {
+      categoryIds.push(val);
+      delete modifier.$set[key];
+    }
+  });
+  if (categoryIds.length) {
+    modifier.$set.categories = categoryIds;
+  }
+  return modifier;
+});


### PR DESCRIPTION
Workaround for https://github.com/aldeed/meteor-autoform/issues/765

Fixes issue #834.