### PR TITLE
Increse specificity of `keyup` search event

### DIFF
--- a/packages/telescope-search/lib/client/templates/search.js
+++ b/packages/telescope-search/lib/client/templates/search.js
@@ -23,7 +23,6 @@ Meteor.startup(function () {
 
   Template[getTemplate('search')].events({
     'keyup .search-field, search .search-field': function(e){
-      console.log("telescope-handler");
       e.preventDefault();
       var val = $(e.target).val(),
           $search = $('.search');

--- a/packages/telescope-search/lib/client/templates/search.js
+++ b/packages/telescope-search/lib/client/templates/search.js
@@ -22,7 +22,8 @@ Meteor.startup(function () {
   });
 
   Template[getTemplate('search')].events({
-    'keyup, search .search-field': function(e){
+    'keyup .search-field, search .search-field': function(e){
+      console.log("telescope-handler");
       e.preventDefault();
       var val = $(e.target).val(),
           $search = $('.search');


### PR DESCRIPTION
It's hard to override the behavior of .search-field in a theme when the
event listener is listening to all ``keyup`` events in the template.
Make it more specific as ``keyup .search-field`` so a theme that doesn't
want the default event listener can override the input class.