### PR TITLE
Use this.userId, not Meteor.user in publications

### DIFF
--- a/packages/telescope-invites/lib/server/publications.js
+++ b/packages/telescope-invites/lib/server/publications.js
@@ -1,4 +1,4 @@
 Meteor.publish('invites', function (userId) {
   var invites = Invites.find({invitingUserId: userId})
-  return (this.userId === userId || isAdmin(Meteor.user())) ? invites : []
+  return (this.userId === userId || isAdminById(this.userId)) ? invites : []
 });


### PR DESCRIPTION
Replace Meteor.user() call in telescope-invites.

Fixes #853.