### PR TITLE
Improve comments loading performance on long threads

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,8 +1,9 @@
 ## v0.15 “SideScope”
 
+* Improved performance when loading comments for long threads (thanks @dandv!).
 * Usernames are now case and space insensitive. `John Smith`, `JohnSmith`, and `johnsmith` are now all considered to be the same username (thanks @splendido!). 
 * Romanian translation (thanks @razvansky!).
-* Now using `feedparser` instead of `htmlparser2` to parse RSS feeds (thanks @delgermurun).
+* Now using `feedparser` instead of `htmlparser2` to parse RSS feeds (thanks @delgermurun!).
 * Now supporting RSS categories (thanks @delgermurun).
 * Added new `postListTop` zone that only appears on post lists. 
 * Now showing tagline on every post list. 

--- a/server/publications/single_comment.js
+++ b/server/publications/single_comment.js
@@ -6,7 +6,7 @@ Meteor.publish('singleCommentAndChildren', function(commentId) {
     var commentIds = [commentId];
     var childCommentIds = _.pluck(Comments.find({parentCommentId: commentId}, {fields: {_id: 1}}).fetch(), '_id');
     commentIds = commentIds.concat(childCommentIds);
-    return Comments.find({_id: {$in: commentIds}});
+    return Comments.find({_id: {$in: commentIds}}, {sort: {score: -1, postedAt: -1}});
   }
   return [];
 });

--- a/server/publications/single_post.js
+++ b/server/publications/single_post.js
@@ -47,7 +47,7 @@ Meteor.publish('postUsers', function(postId) {
 
 Meteor.publish('postComments', function(postId) {
   if (can.viewById(this.userId)){
-    return Comments.find({postId: postId});
+    return Comments.find({postId: postId}, {sort: {score: -1, postedAt: -1}});
   }
   return [];
 });


### PR DESCRIPTION
The screencast below shows the performance [problem I've highlighted on Crater](https://crater.io/comments/NJKs8Skwt7L4ALEt4):

![telescope message shuffling due to lack of sort](https://cloud.githubusercontent.com/assets/33569/6878224/73ab4558-d497-11e4-94d7-9191727907a7.gif)

This PR hopefully fixes that. I can't test at the moment due to [fourseven:scss not installing on Windows](https://github.com/TelescopeJS/Telescope/issues/859) and a similar problem with npm-bcrypt:

> => Meteor 1.1-rc.0 is available. Update this project with 'meteor update'.
=> Errors prevented startup:

>    While checking for fourseven:scss@1.0.0:
   error: No compatible build found

>   While checking for npm-bcrypt@0.7.8_1:
   error: No compatible build found

> => Your application has errors. Waiting for file change.