### PR TITLE
Unify posts hooks

### DIFF
--- a/collections/posts.js
+++ b/collections/posts.js
@@ -364,9 +364,9 @@ submitPost = function (post) {
   if (Meteor.isServer) {
     Meteor.defer(function () { // use defer to avoid holding up client
       // run all post submit server callbacks on post object successively
-      post = postAfterSubmitMethodCallbacks.reduce(function(result, currentFunction) {
-          return currentFunction(result);
-      }, post);
+      postAfterSubmitMethodCallbacks.forEach(function(currentFunction) {
+          currentFunction(post);
+      });
     });
   }
 
@@ -492,10 +492,14 @@ Meteor.methods({
 
     // ------------------------------ Callbacks ------------------------------ //
 
-    // run all post after edit method callbacks successively
-    postAfterEditMethodCallbacks.forEach(function(currentFunction) {
-      currentFunction(modifier, postId);
-    });
+    if (Meteor.isServer) {
+      Meteor.defer(function () { // use defer to avoid holding up client
+        // run all post after edit method callbacks successively
+        postAfterEditMethodCallbacks.forEach(function(currentFunction) {
+          currentFunction(modifier, post);
+        });
+      });
+    }
 
     // ------------------------------ After Update ------------------------------ //
 


### PR DESCRIPTION
This PR unifies posts after submit/edit hooks.

"After" hooks should both be executed only on the server and asynchronously (to avoid holding up the client).
They don't need to modify either the post or the modifier because they happen after insert/update, the after submit hook gets passed the post and the after edit hook gets passed both the modifer and the modified post (this allows fine diffing between the two to take actions only if a particular field was modified).

Shouldn't break anything because it extends the existing API without modifying expected behaviour.