### PR TITLE
Fix a bug where the post submit autoform hook wasn't called

### DIFF
--- a/client/views/posts/post_submit.js
+++ b/client/views/posts/post_submit.js
@@ -2,7 +2,7 @@ AutoForm.hooks({
   submitPostForm: {
 
     before: {
-      submitPost: function(doc) {
+      method: function(doc) {
 
         this.template.$('button[type=submit]').addClass('loading');
 


### PR DESCRIPTION
The autoform docs specify that you should name your hook after the form type, not after the name of the method.

https://github.com/aldeed/meteor-autoform#callbackshooks