### PR TITLE
fix external services not checking for existing email

### DIFF
--- a/client/views/users/user_email.js
+++ b/client/views/users/user_email.js
@@ -16,6 +16,7 @@ Template[getTemplate('user_email')].events({
     var user=Session.get('selectedUserId')? Meteor.users.findOne(Session.get('selectedUserId')) : Meteor.user();
     var update = {
       "profile.email": $target.find('[name=email]').val(),
+      "emails": [ { address : $target.find('[name=email]').val() } ],
       "username": $target.find('[name=username]').val(),
         "slug": slugify($target.find('[name=username]').val())
     };

--- a/lib/vote.js
+++ b/lib/vote.js
@@ -247,7 +247,7 @@ cancelDownvote = function (collection, item, user) {
   // Votes & Score
   var result = collection.update({_id: item && item._id, downvoters: user._id},{
     $pull: {downvoters: user._id},
-    $inc: {downvotes: 1, baseScore: votePower},
+    $inc: {downvotes: -1, baseScore: votePower},
     $set: {inactive: false}
   });
 


### PR DESCRIPTION
When creating an account with oauth (meteor-developer, github, google, etc) the unique identifier emails.$.address is not set anywhere. This is used by accounts-base to handle unique emails. This PR sets the emails.$.address to the email address provided during profile completion to prevent duplicate accounts in the future.