### PR TITLE
Add Docker deployment support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+FROM meteorhacks/meteord:onbuild


### PR DESCRIPTION
Hi,

I've added a Dockerfile to telescope. With we can deploy Telescope with docker very easily, officially. There are few more steps for to do this.

* Create an account an Docker Hub: https://hub.docker.com/account/signup/ (May be an organization called telescope)
* Then click on the automated build as shown below to setup the automated build for every git-push

![screen shot 2015-05-13 at 6 14 33 am](https://cloud.githubusercontent.com/assets/50838/7601695/99e1b4ea-f937-11e4-9a99-b662e5a5406e.png)

In that, you can target different branch to tag version. I prefer this way

* telescope/telescope:latest - master branch
* telescope/telescope:devel - devel branch

May be not everyone want to deploy telescope as a docker image, since telescope needs some customization before deploy. (Themes, etc)
But this would be great for quick deployment or showcasing things around.
