### PR TITLE
Fix Single Day Arrow Nav

### DIFF
--- a/packages/telescope-singleday/lib/client/templates/single_day_nav.js
+++ b/packages/telescope-singleday/lib/client/templates/single_day_nav.js
@@ -14,14 +14,29 @@ Template.single_day_nav.onCreated(function(){
   var currentDate = moment(this.data.terms.date).startOf('day');
   var today = moment(new Date()).startOf('day');
 
-  $(document).bind('keyup', 'left', function(){
-    Router.go($('.prev-link').attr('href'));
+  $(document).bind('keyup', function(event){
+    switch (event.which) {
+      // left arrow
+      case 37:
+        Router.go($('.prev-link').attr('href'));
+        currentDate.subtract(1, 'day');
+        break;
+      // right arrow
+      case 39:
+        if(Users.is.admin(Meteor.user()) || today.diff(currentDate, 'days') > 0) {
+          Router.go($('.next-link').attr('href'));
+          currentDate.add(1, 'day');
+        }
+        break;
+    }
+    event.preventDefault();
   });
 
-  $(document).bind('keyup', 'right', function(){
-    if(Users.is.admin(Meteor.user()) || today.diff(currentDate, 'days') > 0)
-      Router.go($('.next-link').attr('href'));
-  });
+});
+
+Template.single_day_nav.onDestroyed(function(){
+
+  $(document).unbind('keyup'); //clean up to prevent errors on other pages
 
 });
 


### PR DESCRIPTION
This should fix the arrow navigation problem #986. 

- The key event was triggering for basically every key. This should limit to the left and right arrows
- The `currentDate` variable was on getting set `onCreated` and never updating. This would cause `undefined` to be passed to the Router when trying to navigate right from today's view. Now, it is updated after key press.
- I also noticed the key bindings were carrying over to other pages causes `undefined` to get passed to the Router. So, I cleaned it out on template destroyed.

Let me know if you have any thoughts!