### PR TITLE
Fix Removing URL on Edit

### DIFF
--- a/packages/telescope-core/lib/client/templates/forms/urlCustomType.js
+++ b/packages/telescope-core/lib/client/templates/forms/urlCustomType.js
@@ -13,6 +13,9 @@ AutoForm.addInputType("bootstrap-url", {
       }
       return url;
     }
+    else {
+      return null;
+    }
   }
 });
 


### PR DESCRIPTION
This allows you to remove a URL when editing, and fixes #1012.

Looks like it had something to do with the bootstrap-url valueOut function not returning a value when blank.

Let me know if you have any changes. Thanks!