### PR TITLE
fix settings publication to hide private fields (take 2)

### DIFF
--- a/packages/telescope-settings/lib/server/publications.js
+++ b/packages/telescope-settings/lib/server/publications.js
@@ -3,7 +3,7 @@ Meteor.publish('settings', function() {
   var privateFields = {};
 
   // look at Settings.simpleSchema._schema to see which fields should be kept private
-  _.each(Settings.simpleSchema._schema, function (property, key) {
+  _.each(Settings.schema._schema, function (property, key) {
     if (property.private)
       privateFields[key] = false;
   });


### PR DESCRIPTION
The publication was supposed to be removing private fields from the published data, but the schema object was undefined and all properties were being published as a result.