### PR TITLE
Added .startOf('day'); to `today` variable

### DIFF
--- a/packages/telescope-singleday/lib/client/templates/single_day_nav.js
+++ b/packages/telescope-singleday/lib/client/templates/single_day_nav.js
@@ -43,7 +43,7 @@ Template.single_day_nav.onDestroyed(function(){
 Template.single_day_nav.helpers({
   currentDate: function(){
     var currentDate = moment(this.terms.date);
-    var today = moment(new Date());
+    var today = moment(new Date()).startOf('day');
     var diff = today.diff(currentDate, 'days');
     if (diff === 0) {
       return i18n.t("today");


### PR DESCRIPTION
I think it needs this to avoid the timezone affecting the diff. It was displaying the Today label for tomorrow.