### PR TITLE
Fix newsletter author name issue

### DIFF
--- a/packages/telescope-newsletter/lib/server/campaign.js
+++ b/packages/telescope-newsletter/lib/server/campaign.js
@@ -32,7 +32,7 @@ buildCampaign = function (postsArray) {
 
     // the naked post object as stored in the database is missing a few properties, so let's add them
     var properties = _.extend(post, {
-      authorName: Users.getDisplayName(post),
+      authorName: Users.getDisplayName(postUser),
       postLink: Posts.getLink(post),
       profileUrl: Users.getProfileUrl(postUser),
       postPageLink: Posts.getPageUrl(post),


### PR DESCRIPTION
This should fix the author not being shown in newsletters. Looks like it was just the wrong variable being passed to `Users.getDisplayName` :smile_cat: 