### PR TITLE
Handle Deleted User In Email

### DIFF
--- a/packages/telescope-newsletter/lib/server/templates/emailPostItem.handlebars
+++ b/packages/telescope-newsletter/lib/server/templates/emailPostItem.handlebars
@@ -14,7 +14,13 @@
     <a class="post-domain" href="">{{domain}}</a>
     | 
   {{/if}}
-  <span class="post-submitted">Submitted by <a href="{{profileUrl}}" class="comment-link" target="_blank">{{authorName}}</a></span>
+  <span class="post-submitted">
+    {{#if authorName}}
+      Submitted by <a href="{{profileUrl}}" class="comment-link" target="_blank">{{authorName}}</a>
+    {{else}}
+      Submitted
+    {{/if}}
+  </span>
   <span class="post-date">on {{date}}</span>
   |
   <a href="{{postPageLink}}" class="comment-link" target="_blank">{{commentCount}} Comments</a>

--- a/packages/telescope-users/lib/helpers.js
+++ b/packages/telescope-users/lib/helpers.js
@@ -40,7 +40,11 @@ Users.getDisplayNameById = function (userId) {return Users.getDisplayName(Meteor
  * @param {Object} user
  */
 Users.getProfileUrl = function (user) {
-  return Users.getProfileUrlBySlugOrId(user.telescope.slug);
+  if (typeof user === "undefined") {
+    return "";
+  } else {
+    return (user.telescope && user.telescope.slug) ? Users.getProfileUrlBySlugOrId(user.telescope.slug) : "";
+  }
 };
 Users.helpers({getProfileUrl: function () {return Users.getProfileUrl(this);}});
 


### PR DESCRIPTION
This fixes the issue of posts from deleted users showing up in an email campaign. It does two things:

1. Returns blank if trying to get the profile URL of a user that does not exist
2. Just displays "Submitted on" instead of "Submitted by user on" if the user does not exists

Here's an example:
![screenshot 2015-06-18 21 54 59](https://cloud.githubusercontent.com/assets/816517/8246079/1d473e5a-1606-11e5-962b-fca277349bee.png)

Thanks!
