### PR TITLE
fix slug generation on post edit

### DIFF
--- a/packages/telescope-posts/lib/callbacks.js
+++ b/packages/telescope-posts/lib/callbacks.js
@@ -25,9 +25,9 @@ Posts.before.update(function (userId, doc, fieldNames, modifier) {
  * Generate slug when post title is updated
  */
 Posts.before.update(function (userId, doc, fieldNames, modifier) {
-  // if title is being modified, update slug too
-  if (Meteor.isServer && modifier.$set && modifier.$set.title) {
-    modifier.$set.slug = Telescope.utils.slugify(marked(modifier.$set.title));
+  // update slug
+  if (Meteor.isServer && modifier.$set) {
+    modifier.$set.slug = Telescope.utils.slugify(modifier.$set.title);
   }
 });
 


### PR DESCRIPTION
Fixes https://github.com/TelescopeJS/Telescope/issues/1047

Removed the unnecessary `marked()` call that was adding HTML to the slug string.  

Also realized that the `modifier.$set.title` in the `if` statement below was redundant because the `modifier.$set` object always contains all fields regardless of which is being edited.  

So instead of:
```js
Posts.before.update(function (userId, doc, fieldNames, modifier) {
  if (Meteor.isServer && modifier.$set && modifier.$set.title) { 
  ...
```
It can be more concise like:
```js
Posts.before.update(function (userId, doc, fieldNames, modifier) {
  if (Meteor.isServer && modifier.$set) { 
 ...
```