### PR TITLE
make useraccounts:unstyled optional

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -38,6 +38,11 @@ telescope:theme-base
 telescope:theme-hubble
 telescope:update-prompt
 
+
+############ Atmosphere Packages (Optional) ############
+useraccounts:unstyled
+
+
 ############ Your Custom Packages ############
 
 # my-custom-package

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -154,7 +154,7 @@ twitter@1.1.4
 ui@1.0.6
 underscore@1.0.3
 url@1.0.4
-useraccounts:core@1.8.1
+useraccounts:core@1.11.1
 useraccounts:unstyled@1.8.1
 utilities:avatar@0.7.12
 webapp@1.2.0

--- a/packages/telescope-lib/package.js
+++ b/packages/telescope-lib/package.js
@@ -36,7 +36,7 @@ Package.onUse(function (api) {
     'meteorhacks:fast-render@2.3.2',
     'meteorhacks:subs-manager@1.3.0',
     'percolatestudio:synced-cron@1.1.0',
-    'useraccounts:unstyled@1.8.1',
+    'useraccounts:core@1.11.1',
     'manuelschoebel:ms-seo@0.4.1',
     'aramk:tinycolor@1.1.0_1',
     'momentjs:moment@2.10.3',


### PR DESCRIPTION
Fixes https://github.com/TelescopeJS/Telescope/issues/1048

This makes it so `useraccounts:unstyled` can be removed and replaced with one of the other styled options.