### PR TITLE
Improve newsletter

### DIFF
--- a/packages/telescope-email/lib/server/templates/emailWrapper.handlebars
+++ b/packages/telescope-email/lib/server/templates/emailWrapper.handlebars
@@ -91,6 +91,22 @@
           border-bottom: 1px solid #ddd;
           padding: 10px 0;
         }
+        .post-comment-excerpt {
+          padding: 10px;
+          background: #f9f9f9;
+          margin-bottom: 5px;
+        }
+        .post-comment-excerpt:last-child {
+          margin-bottom: 0;
+        }
+        .post-popular-comments h1 {
+          font-size: 14px;
+        }
+        .post-comment-author {
+          float: right;
+          font-size: 13px;
+          color: #a0a0a0;
+        }
     </style>
 </head>
 <body style="margin:0; padding:10px 0;" bgcolor="#ebebeb" leftmargin="0" topmargin="0" marginwidth="0" marginheight="0">

--- a/packages/telescope-newsletter/lib/server/campaign.js
+++ b/packages/telescope-newsletter/lib/server/campaign.js
@@ -39,8 +39,10 @@ buildCampaign = function (postsArray) {
       date: moment(post.postedAt).format("MMMM D YYYY")
     });
 
-    if (post.body)
-      properties.body = marked(Telescope.utils.trimWords(post.body, 20)).replace('<p>', '').replace('</p>', ''); // remove p tags
+    if (post.body) {
+      var bodyText = Telescope.utils.stripHTML(post.htmlBody);
+      properties.body = Telescope.utils.trimWords(bodyText, 20).replace('<p>', '').replace('</p>', ''); // remove p tags
+    }
 
     if(post.url)
       properties.domain = Telescope.utils.getDomain(post.url);

--- a/packages/telescope-newsletter/lib/server/campaign.js
+++ b/packages/telescope-newsletter/lib/server/campaign.js
@@ -39,6 +39,12 @@ buildCampaign = function (postsArray) {
       date: moment(post.postedAt).format("MMMM D YYYY")
     });
 
+    if (post.commentCount > 0)
+      properties.popularComments = Comments.find({postId: post._id}, {sort: {score: -1}, limit: 2, transform: function (comment) {
+        comment.body = Telescope.utils.trimWords(comment.body, 20);
+        return comment;
+      }}).fetch();
+
     if (post.body) {
       var bodyText = Telescope.utils.stripHTML(post.htmlBody);
       properties.body = Telescope.utils.trimWords(bodyText, 20).replace('<p>', '').replace('</p>', ''); // remove p tags

--- a/packages/telescope-newsletter/lib/server/templates/emailPostItem.handlebars
+++ b/packages/telescope-newsletter/lib/server/templates/emailPostItem.handlebars
@@ -12,9 +12,9 @@
 <div class="post-meta">
   {{#if domain}}
     <a class="post-domain" href="">{{domain}}</a>
-    | 
+    |
   {{/if}}
-  
+
   <span class="post-submitted">
     {{#if profileUrl}}
       Submitted by <a href="{{profileUrl}}" class="comment-link" target="_blank">{{authorName}}</a>
@@ -31,7 +31,7 @@
 
 {{#if body}}
   <div class="post-body-excerpt">
-    {{{htmlBody}}}
+    {{body}}
     <a href="{{postPageLink}}" class="comment-link" target="_blank">Read more</a>
   </div>
 {{/if}}
@@ -39,4 +39,3 @@
 
 <br>
 </div>
-

--- a/packages/telescope-newsletter/lib/server/templates/emailPostItem.handlebars
+++ b/packages/telescope-newsletter/lib/server/templates/emailPostItem.handlebars
@@ -36,6 +36,18 @@
   </div>
 {{/if}}
 
+{{#if popularComments}}
+  <div class="post-popular-comments">
+    <h1>Popular comments</h1>
+
+    {{#each popularComments}}
+      <div class="post-comment-excerpt">
+        {{body}}
+        <div class="post-comment-author">{{author}}</div>
+      </div>
+    {{/each}}
+  </div>
+{{/if}}
 
 <br>
 </div>


### PR DESCRIPTION
Trim HTML-stripped version of the post body, because trimming `post.body` gives unexpected results.

e.g.

If post.body was `### Title\n\n * list item 1 * list item 2`, it appears in the newsletter as  `<h3 id="title-list-item-">Title * list item…</h3>`