### PR TITLE
use absolute URL for Users.getProfileUrl

### DIFF
--- a/packages/telescope-email/lib/server/email.js
+++ b/packages/telescope-email/lib/server/email.js
@@ -97,7 +97,7 @@ function adminUserCreationNotification (user) {
   admins.forEach(function(admin){
     if (Users.getSetting(admin, "notifications.users", false)) {
       var emailProperties = {
-        profileUrl: Users.getProfileUrl(user),
+        profileUrl: Users.getProfileUrl(user, true),
         username: Users.getUserName(user)
       };
       var html = Telescope.email.getTemplate('emailNewUser')(emailProperties);


### PR DESCRIPTION
There is a broken link inside the new user account email notification.

![screen shot 2015-07-19 at 4 56 53 am](https://cloud.githubusercontent.com/assets/1114844/8765334/08961e86-2dd5-11e5-9394-c9871c82e297.png)

Whenever I receive a notification about a new user account, the link to the user account looks something like `http:///users/john-ferguson` instead of `https://projectsafe.news/users/john-ferguson`.

```html
<span style="font-size:18px;font-weight:bold;line-height:1.5;margin:0">
  A new user account has been created:
  <a href="http:///users/john-ferguson" style="color:#5593d7;font-weight:bold;text-decoration:none" target="_blank">
    SAFEcrossroads
  </a>
</span>
```

This PR fixes the issue.

```javascript
Users.getProfileUrl = function (user, isAbsolute) {
  if (typeof user === "undefined") {
    return "";
  }
  var isAbsolute = typeof isAbsolute === "undefined" ? false : isAbsolute; // default to false
  var prefix = isAbsolute ? Telescope.utils.getSiteUrl().slice(0,-1) : "";
  return prefix + Router.path("user_profile", {_idOrSlug: user.telescope.slug || user._id});
};
```

I just had to set isAbsolute to `true`.

I did this PR directly into `master` since it's a really simple bugfix and it would be nice to have it fixed quickly. I'm not sure how long it will take before the next version is released, but I can make the PR on `devel` if you prefer :smiley: 