### PR TITLE
Email retreived from FB signup passed to user.telescope.email 

### DIFF
--- a/packages/telescope-users/lib/callbacks.js
+++ b/packages/telescope-users/lib/callbacks.js
@@ -94,6 +94,11 @@ function setupUser (user, options) {
     user.telescope.emailHash = Gravatar.hash(options.email);
   }
 
+   if (user.services.facebook.email) {
+    user.telescope.email = user.services.facebook.email;
+    user.telescope.emailHash = Gravatar.hash(user.services.facebook.email);
+  }
+
   // look in a few places for the displayName
   if (user.profile.username) {
     user.telescope.displayName = user.profile.username;


### PR DESCRIPTION
With Facebook sign-up, the retrieved email is passed from users.services.facebook.email to users.telescope.email