### PR TITLE
Added a RSS route that returns posts filtered by category

### DIFF
--- a/packages/telescope-rss/lib/server/routes.js
+++ b/packages/telescope-rss/lib/server/routes.js
@@ -20,6 +20,16 @@ Meteor.startup(function () {
       where: 'server'
     });
 
+    // Categories RSS
+
+    Router.route('/rss/category/:slug/feed.xml', function () {
+      this.response.write(servePostRSS('new', '/rss/category/:slug/feed.xml',this.params.slug));
+      this.response.end();
+    }, {
+      name: 'rss_posts_category',
+      where: 'server'
+    });
+
     // Top Post RSS
 
     Router.route('/rss/posts/top.xml', function () {

--- a/packages/telescope-rss/lib/server/rss.js
+++ b/packages/telescope-rss/lib/server/rss.js
@@ -11,10 +11,14 @@ getMeta = function(url) {
   };
 };
 
-servePostRSS = function(view, url) {
+servePostRSS = function(view, url, category) {
   var feed = new RSS(getMeta(url));
 
-  var params = Posts.getSubParams({view: view, limit: 20});
+  var terms = {view: view, limit: 20};
+  if (category) {
+    terms.category = category;
+  };
+  var params = Posts.getSubParams(terms);
   delete params['options']['sort']['sticky'];
 
   Posts.find(params.find, params.options).forEach(function(post) {


### PR DESCRIPTION
Hey!

I'm pushing posts from Telescope into Hipchat via Zapier RSS. We wanted to have categories post into specific Hipchat rooms instead of all into the same room. We've also had comments that people would like to select categories to subscribe to in the newsletter.

Hope this helps! Let me know if you have any feedback. I'm not familiar with Meteor. 