### PR TITLE
don't show future posts in daily view

### DIFF
--- a/packages/telescope-daily/lib/client/templates/posts_daily.js
+++ b/packages/telescope-daily/lib/client/templates/posts_daily.js
@@ -12,11 +12,6 @@ Meteor.startup(function () {
       return daysArray;
     },
     context: function () {
-      //if the post is in the future and we aren't showing future, cap at current moment. Else use usual end of day
-      var beforeDate = !Posts.views.baseParameters.showFuture && moment().isBefore(moment(this.date).endOf('day')) ?
-              moment().toDate()
-            : moment(this.date).endOf('day').toDate();
-            
       var context = {
         terms: {
           view: "singleday",

--- a/packages/telescope-daily/lib/client/templates/posts_daily.js
+++ b/packages/telescope-daily/lib/client/templates/posts_daily.js
@@ -12,6 +12,11 @@ Meteor.startup(function () {
       return daysArray;
     },
     context: function () {
+      //if the post is in the future and we aren't showing future, cap at current moment. Else use usual end of day
+      var beforeDate = !Posts.views.baseParameters.showFuture && moment().isBefore(moment(this.date).endOf('day')) ?
+              moment().toDate()
+            : moment(this.date).endOf('day').toDate();
+            
       var context = {
         terms: {
           view: "singleday",

--- a/packages/telescope-posts/lib/parameters.js
+++ b/packages/telescope-posts/lib/parameters.js
@@ -37,10 +37,13 @@ Posts.getSubParams = function (terms) {
     parameters.options.limit = maxLimit;
   }
 
-  // hide future scheduled posts unless "showFuture" is set to true or postedAt is already defined
-  if (!parameters.showFuture && !parameters.find.postedAt)
-    parameters.find.postedAt = {$lte: new Date()};
-
+  // hide future scheduled posts unless "showFuture" is set to true
+  if (!parameters.showFuture) {
+    !!parameters.find.postedAt ?
+      _.extend(parameters.find.postedAt, { $lte: new Date() })
+      : _.extend(parameters.find, { postedAt : { $lte: new Date() }});
+  }
+  
   // filter by category if category _id is provided
   // NOTE: this is a temporary fix because views cannot currently be combined
   if (!!terms.category) {

--- a/packages/telescope-posts/lib/views.js
+++ b/packages/telescope-posts/lib/views.js
@@ -71,7 +71,8 @@ Posts.views.add("pending", function (terms) {
 Posts.views.add("scheduled", function (terms) {
   return {
     find: {postedAt: {$gte: new Date()}},
-    options: {sort: {postedAt: -1}}
+    options: {sort: {postedAt: -1}},
+    showFuture: true
   };
 });
 


### PR DESCRIPTION
currently posts scheduled for the future still show up in the daily view for regular users, which is undesirable. This checks to see if the current time is before the end of the day in question, and if so restrains the query to cap itself to only posts before the current moment.

Not the prettiest but it works and was the best I could think of on short notice :)