### PR TITLE
Fix schema i18n by moving internationalize to collections

### DIFF
--- a/packages/telescope-i18n/i18n.js
+++ b/packages/telescope-i18n/i18n.js
@@ -40,9 +40,8 @@ i18n.t = function (str, options) {
   }
 };
 
-SimpleSchema.prototype.internationalize = function () {
-  var schema = this._schema;
-
+Mongo.Collection.prototype.internationalize = function(){
+  var schema = this.simpleSchema()._schema;
   _.each(schema, function (property, key) {
     if (!property.label) {
       schema[key].label = function () {

--- a/packages/telescope-posts/lib/posts.js
+++ b/packages/telescope-posts/lib/posts.js
@@ -226,7 +226,10 @@ Posts.schema = new SimpleSchema({
 });
 
 // schema transforms
-Posts.schema.internationalize();
+Meteor.startup(function(){
+  // needs to happen after every fields were added
+  Posts.internationalize();
+});
 
 /**
  * Attach schema to Posts collection


### PR DESCRIPTION
The schema internationalization needs to happen on the collection layer, not schemas.

Why is that so ? `Posts.schema` is agnostic to changes made by `Posts.addField`, because it uses `Posts.attachSchema` under the hood, leaving `Posts.schema` untouched.

This means that `Posts.schema.internationalize()` won't take added fields into account, which is problematic.

That's why I moved the `Posts.schema.internationalize` logic to the collection layer instead of the schema layer, because we can use collection2 `simpleSchema` method which returns the aggregated schema using to manage the collection.

Then we need to wrap up `Posts.internationalize()` inside a `Meteor.startup` call to make it run explicitly after every call to `Posts.addField`.
The PR only makes this fix for `Posts`, but it needs to be propagated to every collection previously using `schema.internationalize()`.