### PR TITLE
Use abstraction of adminUsers consistently

### DIFF
--- a/packages/telescope-notifications/lib/callbacks.js
+++ b/packages/telescope-notifications/lib/callbacks.js
@@ -5,7 +5,7 @@
 // add new post notification callback on post submit
 function postSubmitNotification (post) {
 
-  var adminIds = _.pluck(Users.find({'isAdmin': true}, {fields: {_id:1}}).fetch(), '_id');
+  var adminIds = _.pluck(Users.adminUsers({fields: {_id:1}}), '_id');
   var notifiedUserIds = _.pluck(Users.find({'telescope.notifications.posts': true}, {fields: {_id:1}}).fetch(), '_id');
   var notificationData = {
     post: _.pick(post, '_id', 'userId', 'title', 'url')
@@ -27,7 +27,7 @@ function postSubmitNotification (post) {
 Telescope.callbacks.add("postSubmitAsync", postSubmitNotification);
 
 function postApprovedNotification (post) {
-  
+
   var notificationData = {
     post: _.pick(post, '_id', 'userId', 'title', 'url')
   };

--- a/packages/telescope-post-by-feed/lib/server/fetch_feeds.js
+++ b/packages/telescope-post-by-feed/lib/server/fetch_feeds.js
@@ -5,7 +5,7 @@ var Readable = Npm.require('stream').Readable;
 var iconv = Npm.require('iconv-lite');
 
 var getFirstAdminUser = function() {
-  return Meteor.users.findOne({isAdmin: true}, {sort: {createdAt: 1}});
+  return Users.adminUsers({sort: {createdAt: 1}, limit: 1})[0];
 };
 
 var normalizeEncoding = function (contentBuffer) {

--- a/packages/telescope-users/lib/callbacks.js
+++ b/packages/telescope-users/lib/callbacks.js
@@ -14,7 +14,7 @@ Users.after.insert(function (userId, user) {
   if (Users.hasCompletedProfile(user)) {
     Telescope.callbacks.runAsync("profileCompletedAsync", user);
   }
-  
+
 });
 
 /**
@@ -43,7 +43,7 @@ Users.before.update(function (userId, doc, fieldNames, modifier) {
   Users.before.update(function (userId, doc, fieldNames, modifier) {
 
     var user = doc;
-    
+
     // if email is being modified, update user.emails too
     if (Meteor.isServer && modifier.$set && modifier.$set["telescope.email"]) {
 
@@ -116,7 +116,7 @@ function setupUser (user, options) {
   // if this is not a dummy account, and is the first user ever, make them an admin
   user.isAdmin = (!user.profile.isDummy && Meteor.users.find({'profile.isDummy': {$ne: true}}).count() === 0) ? true : false;
 
-  Events.track('new user', {username: user.username, email: user.profile.email});
+  Events.track('new user', {username: user.username, email: user.telescope.email});
 
   return user;
 }

--- a/packages/telescope-users/lib/helpers.js
+++ b/packages/telescope-users/lib/helpers.js
@@ -19,7 +19,7 @@ Users.getUserName = function (user) {
   }
 };
 Users.helpers({getUserName: function () {return Users.getUserName(this);}});
-Users.getUserNameById = function (userId) {return Users.getUserName(Meteor.users.findOne(userId))}; 
+Users.getUserNameById = function (userId) {return Users.getUserName(Meteor.users.findOne(userId))};
 
 /**
  * Get a user's display name (not unique, can take special characters and spaces)
@@ -152,7 +152,7 @@ Users.helpers({getSetting: function (settingName, defaultValue) {return Users.ge
  */
 Users.setSetting = function (user, settingName, value) {
   if (user) {
-    
+
     // all settings should be in the user.telescope namespace, so add "telescope." if needed
     var field = settingName.slice(0,10) === "telescope." ? settingName : "telescope." + settingName;
 
@@ -274,8 +274,8 @@ Users.updateAdmin = function (userId, admin) {
   Users.update(userId, {$set: {isAdmin: admin}});
 };
 
-Users.adminUsers = function () {
-  return this.find({isAdmin : true}).fetch();
+Users.adminUsers = function (options) {
+  return this.find({isAdmin : true}, options).fetch();
 };
 
 Users.getCurrentUserEmail = function () {


### PR DESCRIPTION
A method to fetch users who are admins is defined in [telescope-users/lib/helpers.js](https://github.com/TelescopeJS/Telescope/blob/88b5afc65047300999ddb961492c095be3d886ac/packages/telescope-users/lib/helpers.js#L277-L279), but it wasn't used consistently.

Update ``telescope-notifications`` and ``telescope-post-by-feed`` to use the abstraction rather than querying for isAdmin directly.  To support their use, add an ``options`` parameter to ``Users.adminUsers`` that can be used to provide field/limit options to the lookup.