### PR TITLE
Added data context to commentThreadBottom module

### DIFF
--- a/packages/telescope-comments/lib/client/templates/comment_list.html
+++ b/packages/telescope-comments/lib/client/templates/comment_list.html
@@ -4,5 +4,5 @@
       {{> comment_item}}
     {{/each}}
   </ul>
-  {{> modules "commentThreadBottom"}}
+  {{> modules zone="commentThreadBottom" moduleData=this}}
 </template>


### PR DESCRIPTION
The change for explicit data context settings by moduleData=this broke comment thread subscription since the subscription button had no context for the post it needs to subscribe you to.

This fixes [issue 1129](https://github.com/TelescopeJS/Telescope/issues/1129). 