### PR TITLE
fix showing user_downvoted_posts if not enableDownvotes

### DIFF
--- a/packages/telescope-users/lib/client/templates/profile/user_downvoted_posts.html
+++ b/packages/telescope-users/lib/client/templates/profile/user_downvoted_posts.html
@@ -1,6 +1,8 @@
 <template name="user_downvoted_posts">
-  <div class="user-profile-votes grid grid-module">
-    <h3>{{_ "downvoted_posts"}}</h3>
-    {{> posts_list_controller arguments}}
-  </div>
+  {{#if enableDownvotes}}
+    <div class="user-profile-votes grid grid-module">
+      <h3>{{_ "downvoted_posts"}}</h3>
+      {{> posts_list_controller arguments}}
+    </div>
+  {{/if}}
 </template>


### PR DESCRIPTION
If `enableDownvotes` are enabled, the Downvotes block should not be shown on the user's profile page.