### PR TITLE
replaced getUserName with getDisplayName for comments

### DIFF
--- a/packages/telescope-comments/lib/helpers.js
+++ b/packages/telescope-comments/lib/helpers.js
@@ -29,4 +29,4 @@ Comments.getAuthorName = function (comment) {
     return comment.author;
   }
 };
-Comments.helpers({getAuthorName: function () {return Comments.getDisplayName(this);}});
+Comments.helpers({getAuthorName: function () {return Comments.getAuthorName(this);}});

--- a/packages/telescope-comments/lib/helpers.js
+++ b/packages/telescope-comments/lib/helpers.js
@@ -24,9 +24,9 @@ Comments.helpers({getPageUrl: function () {return Comments.getPageUrl(this);}});
 Comments.getAuthorName = function (comment) {
   var user = Meteor.users.findOne(comment.userId);
   if (user) {
-    return user.getUserName();
+    return user.getDisplayName();
   } else {
     return comment.author;
   }
 };
-Comments.helpers({getAuthorName: function () {return Comments.getAuthorName(this);}});
+Comments.helpers({getAuthorName: function () {return Comments.getDisplayName(this);}});


### PR DESCRIPTION
This is to ensure that in notifications, those users who do not have a username,
are still displayed using their display name.

This is required because certain users are missing user names (caused by the usage of
the social sign-up options which does not create a username)