### PR TITLE
Fix e-mail template overrides by adding the "custom" prefix server-side

### DIFF
--- a/packages/telescope-lib/lib/client/template_replacement.js
+++ b/packages/telescope-lib/lib/client/template_replacement.js
@@ -1,8 +1,5 @@
 Meteor.startup(function () {
 
-  // "custom_" is always loaded last, so it takes priority over every other prefix
-  Telescope.config.addCustomPrefix("custom_");
-
   // loop over custom prefixes
   Telescope.config.customPrefixes.forEach(function (prefix) {
     

--- a/packages/telescope-lib/lib/custom_template_prefix.js
+++ b/packages/telescope-lib/lib/custom_template_prefix.js
@@ -1,0 +1,7 @@
+Meteor.startup(function () {
+
+  // "custom_" is always loaded last, so it takes priority over every other prefix
+  Telescope.config.addCustomPrefix("custom_");
+
+});
+

--- a/packages/telescope-lib/package.js
+++ b/packages/telescope-lib/package.js
@@ -92,6 +92,7 @@ Package.onUse(function (api) {
     'lib/colors.js',
     'lib/icons.js',
     'lib/router.js',
+    'lib/custom_template_prefix.js'
   ], ['client', 'server']);
 
   api.addFiles([


### PR DESCRIPTION
Separate template replacement from adding the initial "custom" prefix,
so that server-side templates (namely e-mails) can also have overrides.