### PR TITLE
Fixing `(error.error === 603)` always results false

### DIFF
--- a/packages/telescope-posts/lib/client/templates/post_submit.js
+++ b/packages/telescope-posts/lib/client/templates/post_submit.js
@@ -51,7 +51,7 @@ AutoForm.hooks({
       Messages.flash(error.message.split('|')[0], 'error'); // workaround because error.details returns undefined
       Messages.clearSeen();
       // $(e.target).removeClass('disabled');
-      if (error.error === 603) {
+      if (error.error === "603") {
         var dupePostId = error.reason.split('|')[1];
         FlowRouter.go('postPage', {slug: '_', _id: dupePostId});
       }


### PR DESCRIPTION
`if (error.error === 603) {...}` is always resulting false even error.error is "603" and the codes insides is never executed. 
It is because error.error is string "603".
It is need double quote to be  `if (error.error === "603") {...}`