### PR TITLE
Pass Herald.collection#deny functions instead of values

### DIFF
--- a/packages/telescope-notifications/lib/herald.js
+++ b/packages/telescope-notifications/lib/herald.js
@@ -5,8 +5,8 @@ if (Meteor.absoluteUrl().indexOf('localhost') !== -1)
 Meteor.startup(function () {
 
   Herald.collection.deny({
-    update: !Users.can.editById,
-    remove: !Users.can.editById
+    update: function(){ return !Users.can.editById; },
+    remove: function(){ return !Users.can.editById; }
   });
 
   // disable all email notifications when "emailNotifications" is set to false


### PR DESCRIPTION
Fixes the following error on startup while using Meteor v1.2.1.

```
Error: deny: Value for `update` must be a function
    at packages/mongo/collection.js:755:1
    at Array.forEach (packages/es5-shim/.npm/package/node_modules/es5-shim/es5-shim.js:417:1)
    at Function._.each._.forEach (packages/underscore/underscore.js:105:1)
    at [object Object].addValidator (packages/mongo/collection.js:752:1)
    at [object Object].Mongo.Collection.deny (packages/mongo/collection.js:804:1)
    at Posts.getNotificationProperties.properties.postAuthorName (lib/herald.js:7:21)
    at /home/sneakertack/work/gh/gh-purple/.meteor/local/build/programs/server/boot.js:249:
```

Prior to https://github.com/meteor/meteor/pull/5442 this error in the Telescope codebase wasn't being properly caught.