### PR TITLE
CSS Transition Breaks SideNav on FF/Safari

### DIFF
--- a/packages/telescope-theme-base/lib/client/scss/specific/_mobile_nav.scss
+++ b/packages/telescope-theme-base/lib/client/scss/specific/_mobile_nav.scss
@@ -38,9 +38,14 @@ $mobile-nav-width: 200px;
   }
 }
 
+/*
+
+CSS Transition breaks side-nav function on FF/Safari 
 .mobile-nav, .inner-wrapper{
   transition: all, 300ms, ease-out, 0ms;
 }
+
+*/
 
 .inner-wrapper{
   position: relative;


### PR DESCRIPTION
Commented out in case it's an issue resolved in future browser versions...