### PR TITLE
Fixing issue #1170

### DIFF
--- a/packages/telescope-embedly/lib/client/autoform-postthumbnail.html
+++ b/packages/telescope-embedly/lib/client/autoform-postthumbnail.html
@@ -2,7 +2,7 @@
   {{#if embedlyKeyExists}}
   <div class="post-thumbnail-outer-wrapper" style="{{outerStyle}}">
     <div class="post-thumbnail-inner-wrapper" style="{{innerStyle}}">
-      <img src="{{this.value}}" class="post-thumbnail-preview" style="{{style}}"/>
+      <img src="{{this.value}}" class="post-thumbnail-preview" alt="" style="{{style}}"/>
       <div class="post-thumbnail-loading">{{>spinner}}</div>
     </div>
   </div>


### PR DESCRIPTION
Add an empty alt attribute for <img tag , to fixing broken empty image placement in firefox
as suggested by @bharatjilledumudi