### PR TITLE
fixes multiple docheads

### DIFF
--- a/packages/telescope-posts/lib/client/templates/post_page.js
+++ b/packages/telescope-posts/lib/client/templates/post_page.js
@@ -1,5 +1,7 @@
 var doSEOStuff = function (post) {
 
+  DocHead.removeDocHeadAddedTags();
+
   var link = {rel: "canonical", href: post.getPageUrl(true)};
   DocHead.addLink(link);
   


### PR DESCRIPTION
Right now, the post page has the meta tags added 3 times, plus the general site meta information.

This removes the unnecessary docheads.