### PR TITLE
Fix Prerender https host issue

### DIFF
--- a/packages/telescope-prerender/lib/server/prerender.js
+++ b/packages/telescope-prerender/lib/server/prerender.js
@@ -1,11 +1,12 @@
 if (Settings.get('prerenderIOToken')) {
-  
+
   var siteUrl = Settings.get('siteUrl') || Meteor.absoluteUrl();
-  var protocol = siteUrl.indexOf('https') !== -1 ? 'https' : 'http'
+  var protocol = siteUrl.indexOf('https') !== -1 ? 'https' : 'http';
+  var host = siteUrl.replace(/https?:\/\//, '').replace('/', '');
 
   var prerender = Npm.require('prerender-node')
     .set('protocol', protocol)
-    .set('host', siteUrl.replace('http://', '').replace('/', ''))
+    .set('host', host)
     .set('prerenderToken', Settings.get('prerenderIOToken'));
 
   Meteor.startup(function() {


### PR DESCRIPTION
I found that the `host` become incorrect value If including https in `siteUrl`.