### PR TITLE
Unblock publications

### DIFF
--- a/packages/telescope-posts/lib/methods.js
+++ b/packages/telescope-posts/lib/methods.js
@@ -184,6 +184,9 @@ Meteor.methods({
       post.userId = user._id;
     }
 
+    post.user_ip = this.connection.clientAddress;
+    post.user_agent = this.connection.httpHeaders["user-agent"];
+
     return Posts.submit(post);
   },
 

--- a/packages/telescope-posts/lib/posts.js
+++ b/packages/telescope-posts/lib/posts.js
@@ -202,6 +202,21 @@ Posts.schema = new SimpleSchema({
     optional: true
   },
   /**
+    Save info for later spam checking on a post. We will use this for the akismet package
+  */
+  user_ip: {
+    type: String,
+    optional: true
+  },
+  user_agent: {
+    type: String,
+    optional: true
+  },
+  referrer: {
+    type: String,
+    optional: true
+  },
+  /**
     The post author's name
   */
   author: {

--- a/packages/telescope-posts/lib/server/publications.js
+++ b/packages/telescope-posts/lib/server/publications.js
@@ -3,7 +3,7 @@ Posts._ensureIndex({"status": 1, "postedAt": 1});
 // Publish a list of posts
 
 Meteor.publish('postsList', function(terms) {
-
+  this.unblock();
   terms.userId = this.userId; // add userId to terms
   
   if(Users.can.viewById(this.userId)){
@@ -20,6 +20,7 @@ Meteor.publish('postsList', function(terms) {
 
 Meteor.publish('postsListUsers', function(terms) {
   
+  this.unblock();
   terms.userId = this.userId; // add userId to terms
   
   if(Users.can.viewById(this.userId)){
@@ -44,6 +45,7 @@ Meteor.publish('postsListUsers', function(terms) {
 Meteor.publish('singlePost', function(postId) {
 
   check(postId, String);
+  this.unblock();
 
   if (Users.can.viewById(this.userId)){
     return Posts.find(postId);
@@ -56,6 +58,7 @@ Meteor.publish('singlePost', function(postId) {
 Meteor.publish('postUsers', function(postId) {
 
   check(postId, String);
+  this.unblock();
 
   if (Users.can.viewById(this.userId)){
     // publish post author and post commenters

--- a/packages/telescope-posts/package.js
+++ b/packages/telescope-posts/package.js
@@ -14,7 +14,8 @@ Package.onUse(function (api) {
     'telescope:i18n@0.25.6',
     'telescope:settings@0.25.6',
     'telescope:users@0.25.6',
-    'telescope:comments@0.25.6'
+    'telescope:comments@0.25.6',
+    'meteorhacks:unblock'
   ]);
 
   api.addFiles([


### PR DESCRIPTION
Publications are blocking and there is really no reason to, making the post publications synchronous doesn't help anything. I used the `meteorhacks:unblock` package and it seems to be helping load times on Crater so far.

Hattip to @arunoda for his help on this.