### PR TITLE
supply default email based on 3rd party login, if possible

### DIFF
--- a/packages/telescope-users/lib/callbacks.js
+++ b/packages/telescope-users/lib/callbacks.js
@@ -98,8 +98,14 @@ function setupUser (user, options) {
   // look in a few places for the user email
   if (options.email) {
     user.telescope.email = options.email;
+  } else if (user.services['meteor-developer'] && user.services['meteor-developer'].emails) {
+    user.telescope.email = _.findWhere(user.services['meteor-developer'].emails, { primary: true }).address;
   } else if (user.services.facebook && user.services.facebook.email) {
     user.telescope.email = user.services.facebook.email;
+  } else if (user.services.github && user.services.github.email) {
+    user.telescope.email = user.services.github.email;
+  } else if (user.services.google && user.services.google.email) {
+    user.telescope.email = user.services.google.email;
   }
 
   // generate email hash


### PR DESCRIPTION
Most sites, when you log in with a 3rd party OAuth provider, will fill in whatever possible fields when making a new account.  Mirroring the capability here.

I was unable to test with Weibo due to not having a Chinese phone number, but I tested with the other external services mentioned [here](http://docs.meteor.com/#/full/meteor_loginwithexternalservice).  The ones I didn't add support for do not provide the email address back by default.