### PR TITLE
Set counter name to category id instead of category slug

### DIFF
--- a/packages/telescope-tags/lib/helpers.js
+++ b/packages/telescope-tags/lib/helpers.js
@@ -63,6 +63,6 @@ Categories.helpers({getUrl: function () {return Categories.getUrl(this);}});
  * @param {Object} category
  */
  Categories.getCounterName = function (category) {
-  return category.slug + "-postsCount";
+  return category._id + "-postsCount";
  }
  Categories.helpers({getCounterName: function () {return Categories.getCounterName(this);}});


### PR DESCRIPTION
If using slug, when we edit the category, the slug changes and the counter
become 0 until we refresh the browser. I think it's better if we stick with
_id because _id is not changing.