### PR TITLE
Added colorpicker for color options in Settings page

### DIFF
--- a/packages/telescope-settings/lib/settings.js
+++ b/packages/telescope-settings/lib/settings.js
@@ -296,7 +296,8 @@ Settings.schema = new SimpleSchema({
     optional: true,
     autoform: {
       group: "05_colors",
-      instructions: 'Used for button backgrounds.'
+      instructions: 'Used for button backgrounds.',
+      type: "bootstrap-minicolors"
     }
   },
   accentContrastColor: {
@@ -304,7 +305,8 @@ Settings.schema = new SimpleSchema({
     optional: true,
     autoform: {
       group: "05_colors",
-      instructions: 'Used for button text.'
+      instructions: 'Used for button text.',
+      type: "bootstrap-minicolors"
     }
   },
   secondaryColor: {
@@ -312,7 +314,8 @@ Settings.schema = new SimpleSchema({
     optional: true,
     autoform: {
       group: "05_colors",
-      instructions: 'Used for the navigation background.'
+      instructions: 'Used for the navigation background.',
+      type: "bootstrap-minicolors"
     }
   },
   secondaryContrastColor: {
@@ -320,7 +323,8 @@ Settings.schema = new SimpleSchema({
     optional: true,
     autoform: {
       group: "05_colors",
-      instructions: 'Used for header text.'
+      instructions: 'Used for header text.',
+      type: "bootstrap-minicolors"
     }
   },
   fontUrl: {

--- a/packages/telescope-settings/package.js
+++ b/packages/telescope-settings/package.js
@@ -11,8 +11,9 @@ Package.onUse(function(api) {
   api.versionsFrom(['METEOR@1.0']);
 
   api.use([
-    'telescope:lib@0.25.7', 
-    'telescope:i18n@0.25.7'
+    'telescope:lib@0.25.7',
+    'telescope:i18n@0.25.7',
+    'hausor:autoform-bs-minicolors@1.0.0'
   ]);
 
   api.addFiles([

--- a/packages/telescope-theme-base/lib/client/scss/global/_forms.scss
+++ b/packages/telescope-theme-base/lib/client/scss/global/_forms.scss
@@ -55,6 +55,10 @@ form, .accounts-dialog{
         display:inline-block;
         margin-bottom:0;
       }
+      .minicolors-theme-bootstrap .minicolors-swatch {
+        top: 1px;
+        left: 1px;
+      }
     }
     &.inline{
       .controls{


### PR DESCRIPTION
Hi,

As requested in the Telescope Roadmap, I added a colorpicker for color options in the Setting page. I also modified the forms.scss in telescope base theme to correct the color picker's position.

It's my first pull request so don't hesitate to give any feedback.

Thank you !