### PR TITLE
fixed <a> href in post_author template

### DIFF
--- a/packages/telescope-posts/lib/client/templates/modules/post_author.html
+++ b/packages/telescope-posts/lib/client/templates/modules/post_author.html
@@ -1,5 +1,5 @@
 <template name="post_author">
   <div class="{{moduleClass}}">
-    <a class="post-author" href="{{getProfileUrl item.userId}}">{{displayName}}</a>
+    <a class="post-author" href="{{getProfileUrl userId}}">{{displayName}}</a>
   </div>
 </template>


### PR DESCRIPTION
Link to author profile wasn't working (refer to meta.telescopeapp.org to see broken link). Just corrected it to match with the post_avatars template, which *was* working.

P.S. If anyone can explain what was going on I'd like it because I still don't really understand