### PR TITLE
Add siteUrl in front of action link. The link is wrong

### DIFF
--- a/packages/telescope-invites/lib/server/invites.js
+++ b/packages/telescope-invites/lib/server/invites.js
@@ -69,7 +69,8 @@ Meteor.methods({
             communityName : communityName,
             actionLink : user ? Telescope.utils.getSigninUrl() : Telescope.utils.getSignupUrl(),
             invitedBy : Users.getDisplayName(currentUser),
-            profileUrl : Users.getProfileUrl(currentUser)
+            profileUrl : Users.getProfileUrl(currentUser),
+            siteUrl: Settings.get("siteUrl")
           };
 
       Meteor.setTimeout(function () {

--- a/packages/telescope-invites/lib/server/templates/emailInvite.handlebars
+++ b/packages/telescope-invites/lib/server/templates/emailInvite.handlebars
@@ -3,9 +3,9 @@
 </span><br><br>
 
 {{#if newUser}}
-  <a href="{{actionLink}}">Join {{communityName}}</a>
+  <a href="{{siteUrl}}{{actionLink}}">Join {{communityName}}</a>
 {{else}}
-  <a href="{{actionLink}}">Sign in to {{communityName}}</a>
+  <a href="{{siteUrl}}{{actionLink}}">Sign in to {{communityName}}</a>
 {{/if}}
 
 <br><br>


### PR DESCRIPTION
Current invite link is broken.

![airmail 2016-02-09 18-36-54](https://cloud.githubusercontent.com/assets/1147918/12915218/437b7478-cf5c-11e5-98aa-25caf2fc1051.png)


Maybe it's because without `siteUrl`. So I just add it at the beginning of the link.