### PR TITLE
Fix Username already exists issue [403]

### DIFF
--- a/packages/nova-getting-started/lib/server/dummy_content.js
+++ b/packages/nova-getting-started/lib/server/dummy_content.js
@@ -108,7 +108,7 @@ Meteor.methods({
 
 Meteor.startup(function () {
   // insert dummy content only if createDummyContent hasn't happened and there aren't any posts in the db
-  if (!Events.findOne({name: 'createDummyContent'}) && !Posts.find().count()) {
+  if (!Users.find().count() && !Events.findOne({name: 'createDummyContent'}) && !Posts.find().count()) {
     createDummyUsers();
     createDummyPosts();
     createDummyComments();


### PR DESCRIPTION
On starting with the Nova version, there's this persistant ` Error: Username already exists. [403]` issue. This PR fixes that by checking if there are users first.