### PR TITLE
Add PostViews to loading & no posts scenarios; fix paths on Links generation …

### DIFF
--- a/packages/base-components/lib/posts/list/PostList.jsx
+++ b/packages/base-components/lib/posts/list/PostList.jsx
@@ -15,13 +15,19 @@ const PostList = props => {
   } else if (!props.ready) {
     return (
       <div className="postList">
-        <PostsLoading/>
+        <PostViews />
+        <div className="post-list-content">
+          <PostsLoading/>
+        </div>
       </div>
     )
   } else {
     return (
       <div className="postList">
-        <NoPosts/>
+        <PostViews />
+        <div className="post-list-content">
+          <NoPosts/>
+        </div>
       </div>
     )  
   }

--- a/packages/base-components/lib/posts/list/PostViews.jsx
+++ b/packages/base-components/lib/posts/list/PostViews.jsx
@@ -12,7 +12,7 @@ const PostViews = props => {
       <h4>Sort By:</h4>
       <ul>
         {views.map(view => 
-          <li key={view}><a href={FlowRouter.extendPathWithQueryParams("posts.list", {}, {view: view})}>{view}</a></li>
+          <li key={view}><a href={FlowRouter.path("/", null, {view})}>{view}</a></li>
         )}
       </ul>
     </div>


### PR DESCRIPTION
I added the `PostViews` component to the loading and not found scenarios for the `PostList` because it's more visually consistent across slow loading, and if you don't have it when there are no posts you're sort of stuck without a way out.

Also, the links were broken so I fixed that. I'm guessing that FlowRouter method was deprecated...?