### PR TITLE
Use current path and change params for post sorting

### DIFF
--- a/packages/base-components/lib/posts/list/PostViews.jsx
+++ b/packages/base-components/lib/posts/list/PostViews.jsx
@@ -12,7 +12,7 @@ const PostViews = props => {
       <h4>Sort By:</h4>
       <ul>
         {views.map(view => 
-          <li key={view}><a href={FlowRouter.extendPathWithQueryParams("posts.list", {}, {view: view})}>{view}</a></li>
+          <li key={view}><a href={FlowRouter.path(FlowRouter.current().route.pathDef, {}, {view: view})}>{view}</a></li>
         )}
       </ul>
     </div>


### PR DESCRIPTION
This is another attempt to get the sorting working properly and anticipates the sorting to be used on a different URL. This gets the current path using FlowRouter's `.current()` method ([see here](https://github.com/kadirahq/flow-router#flowroutercurrent)) and uses that in the `pathDef`.

I can't actually test this in categories because there's no working route, but it should work then too.

What's clear is that the current version has an issue. If I click "top" and then click "new" the URL becomes: `http://localhost:3000/?view=new&options=%255Bobject%2520Object%255D&currentUserId=xxT6sYMbYGcjp4foH`