### PR TITLE
update to version of alt:react-accounts* that doesn't depend on react-runtime

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -40,3 +40,4 @@ base-components
 base-styles
 
 nova-demo
+alt:react-npm

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -9,8 +9,10 @@ aldeed:schema-deny@1.0.1
 aldeed:schema-index@1.0.1
 aldeed:simple-schema@1.5.3
 allow-deny@1.0.1-beta.11
-alt:react-accounts-ui@1.1.0
-alt:react-accounts-unstyled@1.1.0
+alt:react@1.0.1
+alt:react-accounts-ui@1.2.0
+alt:react-accounts-unstyled@1.2.0
+alt:react-npm@1.0.0
 arillo:flow-router-helpers@0.5.1
 autoupdate@1.2.5-beta.11
 babel-compiler@6.4.0-beta.11

--- a/packages/base-components/package.js
+++ b/packages/base-components/package.js
@@ -20,7 +20,7 @@ Package.onUse(function (api) {
 
     // third-party packages
 
-    'alt:react-accounts-ui@1.1.0',
+    'alt:react-accounts-ui@1.2.0',
     // 'alt:react-accounts-unstyled',
     'dburles:spacebars-tohtml@1.0.1',
   ]);


### PR DESCRIPTION
New version doesn't have a dependency on the Meteor react-runtime package so works well with the NPM react version.

There are other packages (utilities:react-list-container, utilities:react-form-containers) in Telescope that do use the react-runtime so until those are updated the local react-runtime package is still needed as an override to remove the duplicate React issue.
