### PR TITLE
always link directly to first page of most recent docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ Note that Telescope is distributed under the [MIT License](http://opensource.org
 
 Note that while simply cloning this repository will work, it is recommended you clone the [sample project](https://github.com/TelescopeJS/sample-project/) repository instead for a simpler workflow.
 
-Please refer to [the documentation](http://telescope.readme.io/v0.20/docs/installing-telescope) for more instructions on installing Telescope.
+Please refer to [the documentation](http://telescope.readme.io/docs) for more instructions on installing Telescope.
 
 ### Learn More
 
 - [Homepage](http://telescopeapp.org)
 - [Demo](http://demo2.telescopeapp.org)
 - [Sample Project](https://github.com/TelescopeJS/sample-project/)
-- [Documentation](http://telescope.readme.io)
+- [Documentation](http://telescope.readme.io/docs)
 - [Roadmap](https://trello.com/b/oLMMqjVL/telescope-roadmap)
 - [Slack](http://slack.telescopeapp.org/)
 - [Meta](http://meta.telescopeapp.org/) – Discussions about Telescope


### PR DESCRIPTION
- Previous links were to the readme landing welcome page or to an outdated docs version