### PR TITLE
fixing typo in newCommentSubscribed notification

### DIFF
--- a/packages/telescope-notifications/lib/notifications.js
+++ b/packages/telescope-notifications/lib/notifications.js
@@ -61,7 +61,7 @@ var notifications = {
       return this.authorName+' left a new comment on "' + this.postTitle + '"';
     },
     emailTemplate: "notification_new_comment",
-    onsite: "notification_new_comment"
+    onsiteTemplate: "notification_new_comment"
   }
 
 };


### PR DESCRIPTION
Without this, the following bug would happen:

When a user adds a comment to a post with a subscriber that is not otherwise notified, the notification doesn't get sent and the server repots the following error: "Exception in defer callback: Error: [Can't start Herald.escalate: TypeError: undefined is not a function]" when trying to notify a subscriber of a comment.