### PR TITLE
Fixed issue with UserEdit.jsx and undefined EditComponent

### DIFF
--- a/packages/nova-base-components/lib/users/UserEdit.jsx
+++ b/packages/nova-base-components/lib/users/UserEdit.jsx
@@ -1,26 +1,34 @@
 import React, { PropTypes, Component } from 'react';
+import {EditDocument} from 'meteor/nova:forms';
 
 const UserEdit = ({document, currentUser}) => {
 
   const user = document;
-  const label = `Edit profile for ${Users.getDisplayName(user)}`;
+  //const label = `Edit profile for ${Users.getDisplayName(user)}`;
 
-  ({CanEditUser, EditDocument} = Telescope.components);
+  ({CanEditUser} = Telescope.components);
+
+  const editComponent = renderEditDocument(currentUser,user);
 
   return (
     <CanEditUser user={currentUser} userToEdit={user}>
       <div className="edit-user-form">
         <h3>Edit Account</h3>
-        <EditDocument 
-          currentUser={currentUser}
-          collection={Meteor.users} 
-          document={user} 
-          methodName="users.edit"
-        />
+          {editComponent}
       </div>
     </CanEditUser>
   )
 }
+
+const renderEditDocument = (currentUser,user) => (
+    <EditDocument
+        currentUser={currentUser}
+        collection={Meteor.users}
+        document={user}
+        methodName="users.edit"
+    />
+);
+
   
 UserEdit.propTypes = {
   document: React.PropTypes.object.isRequired,
@@ -28,3 +36,4 @@ UserEdit.propTypes = {
 }
 
 module.exports = UserEdit;
+export default UserEdit;

--- a/packages/nova-forms/lib/EditDocument.jsx
+++ b/packages/nova-forms/lib/EditDocument.jsx
@@ -59,6 +59,8 @@ const EditDocument = React.createClass({
     const collection = this.props.collection;
     const fields = this.getFields();
 
+    console.log('called editdocument render')
+
     const style = {
       maxWidth: "800px",
       width: "100%"

--- a/packages/nova-forms/lib/export.js
+++ b/packages/nova-forms/lib/export.js
@@ -11,3 +11,4 @@ import NewDocument from "./NewDocument.jsx";
 import EditDocument from "./EditDocument.jsx";
 
 export default {NewDocument, EditDocument};
+module.exports = {NewDocument, EditDocument};


### PR DESCRIPTION
EditComponent wasn't available through Telescope.components. The import from nova:forms for UserEdit.jsx fixed it. I had the following issue
`Warning: React.createElement: 
type should not be null, undefined, boolean, or number. 
It should be a string (for DOM elements) or a 
ReactClass (for composite components). 
Check the render method of `UserEdit`.`