### PR TITLE
Show login form instead of new comment form if the user is not logged in

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -68,7 +68,6 @@ meteorhacks:inject-data@2.0.0
 meteorhacks:inject-initial@1.0.3
 meteorhacks:meteorx@1.4.1
 meteorhacks:picker@1.0.3
-meteorhacks:subs-manager@1.6.4
 meteorhacks:unblock@1.1.0
 meteorspark:util@0.2.0
 minifier-css@1.1.9
@@ -135,7 +134,7 @@ srp@1.0.6
 standard-minifier-css@1.0.4
 standard-minifier-js@1.0.4
 standard-minifiers@1.0.4
-studiointeract:react-accounts-ui@1.0.7
+std:accounts-ui@1.1.0
 tap:i18n@1.7.0
 templating@1.1.7
 templating-tools@1.0.2

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -134,7 +134,7 @@ srp@1.0.6
 standard-minifier-css@1.0.4
 standard-minifier-js@1.0.4
 standard-minifiers@1.0.4
-std:accounts-ui@1.1.0
+std:accounts-ui@1.1.1
 tap:i18n@1.7.0
 templating@1.1.7
 templating-tools@1.0.2

--- a/packages/nova-base-components/lib/posts/PostPage.jsx
+++ b/packages/nova-base-components/lib/posts/PostPage.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Accounts } from 'meteor/std:accounts-ui';
 import SmartContainers from "meteor/utilities:react-list-container";
 const ListContainer = SmartContainers.ListContainer;
 
@@ -32,14 +33,19 @@ const PostPage = ({document, currentUser}) => {
           joins={Comments.getJoins()}
         ><CommentList/></ListContainer>
 
-        <div className="post-new-comment">
-          <h4>New Comment:</h4>
-          <CommentNew type="comment" postId={post._id} />
-        </div>
+        { currentUser ?
+          <div className="post-new-comment">
+            <h4>New Comment:</h4>
+            <CommentNew type="comment" postId={post._id} />
+          </div> :
+          <div>
+            <h4>Please login to comment:</h4>
+            <Accounts.ui.LoginForm />
+          </div> }
       </div>
 
     </div>
   )
-}
+};
 
 module.exports = PostPage;

--- a/packages/nova-base-components/lib/users/AccountsMenu.jsx
+++ b/packages/nova-base-components/lib/users/AccountsMenu.jsx
@@ -1,9 +1,9 @@
 import React, { PropTypes, Component } from 'react';
-import Router from '../router.js'
+import Router from '../router.js';
 import { Dropdown } from 'react-bootstrap';
 import { Button, Input } from 'react-bootstrap';
 
-import { Accounts, redirect } from 'meteor/studiointeract:react-accounts-ui';
+import { Accounts } from 'meteor/std:accounts-ui';
 
 const AccountsMenu = () => {
 
@@ -19,7 +19,7 @@ const AccountsMenu = () => {
       </Dropdown.Menu>
     </Dropdown>
   ) 
-}
+};
 
 module.exports = AccountsMenu;
 export default AccountsMenu;

--- a/packages/nova-base-components/lib/users/AccountsMenu.jsx
+++ b/packages/nova-base-components/lib/users/AccountsMenu.jsx
@@ -28,6 +28,8 @@ export default AccountsMenu;
 
 Accounts.ui.config({
   passwordSignupFields: 'USERNAME_AND_EMAIL',
+  onSignedInHook: () => {},
+  onSignedOutHook: () => {},
 });
 
 class AccountsButton extends Accounts.ui.Button {
@@ -52,12 +54,6 @@ class AccountsField extends Accounts.ui.Field {
   }
 }
 
-/**
- * accounts-facebook & accounts-twitter are used by nova:lib, so the oauthServices recognize these two keys.
- * However, they are not enabled by default (no credentials)
- * => Don't show the social buttons if the service exists but is not enabled.
- */
-
 class AccountsSocialButtons extends Accounts.ui.SocialButtons {
   render () {
     let { oauthServices = {}, className = "social_buttons" } = this.props;
@@ -71,10 +67,6 @@ class AccountsSocialButtons extends Accounts.ui.SocialButtons {
 
   }
 }
-
-/**
- * Same stuff as above -> filter services registered but not enabled
- */
 
 class AccountsPasswordOrService extends Accounts.ui.PasswordOrService {
   render () {

--- a/packages/nova-base-components/lib/users/AccountsMenu.jsx
+++ b/packages/nova-base-components/lib/users/AccountsMenu.jsx
@@ -52,5 +52,57 @@ class AccountsField extends Accounts.ui.Field {
   }
 }
 
+/**
+ * accounts-facebook & accounts-twitter are used by nova:lib, so the oauthServices recognize these two keys.
+ * However, they are not enabled by default (no credentials)
+ * => Don't show the social buttons if the service exists but is not enabled.
+ */
+
+class AccountsSocialButtons extends Accounts.ui.SocialButtons {
+  render () {
+    let { oauthServices = {}, className = "social_buttons" } = this.props;
+    return(
+      <div className={ className }>
+        {Object.keys(oauthServices)
+          .filter(service => oauthServices[service].disabled) // filter services registered but not enabled
+          .map((id, i) => <Accounts.ui.Button {...oauthServices[id]} key={i} />)}
+      </div>
+    );
+
+  }
+}
+
+/**
+ * Same stuff as above -> filter services registered but not enabled
+ */
+
+class AccountsPasswordOrService extends Accounts.ui.PasswordOrService {
+  render () {
+    let {
+      oauthServices = {},
+      className,
+      style = {}
+      } = this.props;
+    let { hasPasswordService } = this.state;
+    let labels = Object.keys(oauthServices)
+      .filter(service => oauthServices[service].disabled) // filter services registered but not enabled
+      .map(service => oauthServices[service].label);
+    if (labels.length > 2) {
+      labels = [];
+    }
+
+    if (hasPasswordService && labels.length > 0) {
+      return (
+        <div style={ style } className={ className }>
+          { `${T9n.get('or use')} ${ labels.join(' / ') }` }
+        </div>
+      );
+    }
+    return null;
+  }
+}
+
 Accounts.ui.Button = AccountsButton;
 Accounts.ui.Field = AccountsField;
+Accounts.ui.SocialButtons = AccountsSocialButtons;
+Accounts.ui.PasswordOrService = AccountsPasswordOrService;

--- a/packages/nova-base-components/lib/users/UserMenu.jsx
+++ b/packages/nova-base-components/lib/users/UserMenu.jsx
@@ -1,5 +1,7 @@
 import React, { PropTypes, Component } from 'react';
-import Router from '../router.js'
+import { Meteor } from 'meteor/meteor';
+import { Accounts } from 'meteor/std:accounts-ui';
+import Router from '../router.js';
 import { Dropdown, MenuItem } from 'react-bootstrap';
 
 const UserMenu = ({user}) => {
@@ -15,7 +17,7 @@ const UserMenu = ({user}) => {
       <Dropdown.Menu>
         <MenuItem className="dropdown-item" eventKey="1" href={Router.path("users.single", {slug: user.telescope.slug})}>Profile</MenuItem>
         <MenuItem className="dropdown-item" eventKey="2" href={Router.path("account")}>Edit Account</MenuItem>
-        <MenuItem className="dropdown-item" eventKey="3" href={Router.path("account")} onClick={Meteor.logout}>Log Out</MenuItem>
+        <MenuItem className="dropdown-item" eventKey="3" onClick={() => Meteor.logout(Accounts.ui._options.onSignedOutHook())}>Log Out</MenuItem>
       </Dropdown.Menu>
     </Dropdown>
   ) 

--- a/packages/nova-base-components/package.js
+++ b/packages/nova-base-components/package.js
@@ -25,7 +25,7 @@ Package.onUse(function (api) {
     // 'alt:react-accounts-ui@1.2.1',
     // 'alt:react-accounts-unstyled@1.2.1',
     // 'studiointeract:react-accounts-ui-basic@1.0.1',
-    'studiointeract:react-accounts-ui@1.0.7',
+    'std:accounts-ui@1.1.0',
     'dburles:spacebars-tohtml@1.0.1',
     'utilities:react-list-container'
   ]);

--- a/packages/nova-base-components/package.js
+++ b/packages/nova-base-components/package.js
@@ -25,7 +25,7 @@ Package.onUse(function (api) {
     // 'alt:react-accounts-ui@1.2.1',
     // 'alt:react-accounts-unstyled@1.2.1',
     // 'studiointeract:react-accounts-ui-basic@1.0.1',
-    'std:accounts-ui@1.1.0',
+    'std:accounts-ui@1.1.1',
     'dburles:spacebars-tohtml@1.0.1',
     'utilities:react-list-container'
   ]);

--- a/packages/nova-users/lib/server/create_user.js
+++ b/packages/nova-users/lib/server/create_user.js
@@ -1,4 +1,6 @@
+/*
 Accounts.onCreateUser(function(options, user){
   user = Telescope.callbacks.run("onCreateUser", user, options);
   return user;
 });
+*/


### PR DESCRIPTION
Roadmap task : https://trello.com/c/nhjQ4TaI/20-comments

Here is what I have done @SachaG:

1. I have checked if there is a `currentUser` or not :
**=>** Render `<CommentNew />` if the user is logged in, render `<Accounts.ui.LoginForm />` if he is not logged in.

2. I have realized that @timbrandin moved [studiointeract:react-accounts-ui](https://atmospherejs.com/studiointeract/react-accounts-ui) to [std:accounts-ui](https://atmospherejs.com/std/accounts-ui).
**=>** Switch from `studiointeract:react-accounts-ui` to `std:accounts-ui`.

3. This new version handles social buttons and logging with password or service, `<SocialButtons />` and `<PasswordOrService />` components.
As `accounts-facebook` & `accounts-twitter` are used by `nova:lib`, the `oauthServices` prop passed to them recognize two keys, `facebook` and `twitter`. However, they are not enabled by default (no credentials).
**=>** Tweak on the _social buttons_ & _password or service text_ to filter on the service to see if it is enabled or not, in order to not showing buttons that tell "Service not configured" on clicked.

4. `std:accounts-ui` redirects after signed in/out to home path by default
**=>** Explictly assign hooks that return a function that doesn't do anything.

:question: :question: [ping @timbrandin @maz-dev @SachaG]
I just see that @maz-dev is working on the social buttons to show a configuration form. https://github.com/studiointeract/accounts-ui/issues/12
Shall we wait for it to be done? Or let the user configure by hand services with `ServiceConfiguration` in the _Nova "Do It Yourself" customization state of mind_? 
**=>** Is this **Point 3.** is bringing value to Nova and/or Accounts-UI? I'm not really sure but I had fun tweaking it haha! :sweat_smile: 