### PR TITLE
HeadTags: dochead instead of react-helmet

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -26,6 +26,7 @@ check@1.1.2
 chuangbo:cookie@1.1.0
 chuangbo:marked@0.3.5_1
 coffeescript@1.0.15
+cosmos:browserify@0.8.4
 dburles:collection-helpers@1.0.4
 dburles:spacebars-tohtml@1.0.1
 ddp@1.2.3
@@ -40,6 +41,7 @@ ecmascript@0.4.1
 ecmascript-runtime@0.2.8
 ejson@1.0.9
 email@1.0.10
+es5-shim@4.5.8
 fortawesome:fontawesome@4.5.0
 fourseven:scss@3.4.1
 geojson-utils@1.0.6
@@ -53,6 +55,7 @@ jparker:crypto-core@0.1.0
 jparker:crypto-md5@0.1.1
 jparker:gravatar@0.4.1
 jquery@1.11.6
+kadira:dochead@1.4.0
 kadira:flow-router-ssr@3.12.2
 livedata@1.0.16
 localstorage@1.0.7

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "formsy-react": "^0.17.0",
     "formsy-react-components": "^0.6.6",
     "js-cookie": "^2.1.0",
+    "load-script": "^1.0.0",
     "react": "^0.14.7",
     "react-addons-pure-render-mixin": "^0.14.7",
     "react-bootstrap": "^0.28.4",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "react-addons-pure-render-mixin": "^0.14.7",
     "react-bootstrap": "^0.28.4",
     "react-dom": "^0.14.6",
-    "react-helmet": "^2.3.1",
     "react-komposer": "^1.4.1",
     "react-mounter": "^1.1.0",
     "react-no-ssr": "^1.0.1",

--- a/packages/nova-base-components/lib/common/HeadTags.jsx
+++ b/packages/nova-base-components/lib/common/HeadTags.jsx
@@ -1,32 +1,51 @@
-import React from 'react';
-import Helmet from 'react-helmet';
+import React, { PropTypes, Component } from 'react';
+import { DocHead } from 'meteor/kadira:dochead';
 
-const HeadTags = ({url, title, description, image}) => {
-	return (
-		<Helmet
-			title={title}
-			base={{href: Telescope.utils.getSiteUrl()}}
-			meta={[
-				{charset: "utf-8"},
-				{name: "description", content: description},
-				// facebook
-				{property: "og:type", content: "article"},
-				{property: "og:url", content: url},
-				{property: "og:image", content: image},
-				{property: "og:title", content: title},
-				{property: "og:description", content: description},
-				//twitter
-				{name: "twitter:card", content: "summary"},
-				{name: "twitter:image:src", content: image},
-				{name: "twitter:title", content: title},
-				{name: "twitter:description", content: description}
-			]}
-			link={[
-				{rel: "canonical", href: Telescope.utils.getSiteUrl()},
-				{rel: "shortcut icon", href: Telescope.settings.get("favicon", "/img/favicon.ico")}
-			]}
-		/>
-	);
+class HeadTags extends Component {
+	render() {
+
+		const url = this.props.url ? this.props.url : Telescope.utils.getSiteUrl();
+		const title = this.props.title ? this.props.title : Telescope.settings.get("title");
+		const description = this.props.description ? this.props.description : Telescope.settings.get("tagline");
+		const image = this.props.image ? this.props.image : Telescope.utils.getSiteUrl() + Telescope.settings.get("logoUrl");
+
+		const metas = [
+			{charset: "utf-8"},
+			{name: "description", content: description},
+			// facebook
+			{property: "og:type", content: "article"},
+			{property: "og:url", content: url},
+			{property: "og:image", content: image},
+			{property: "og:title", content: title},
+			{property: "og:description", content: description},
+			//twitter
+			{name: "twitter:card", content: "summary"},
+			{name: "twitter:image:src", content: image},
+			{name: "twitter:title", content: title},
+			{name: "twitter:description", content: description}
+		];
+
+		const links = [
+			{rel: "canonical", href: Telescope.utils.getSiteUrl()},
+			{rel: "shortcut icon", href: Telescope.settings.get("favicon", "/img/favicon.ico")}
+		];
+
+		return (
+			<div>
+				{DocHead.setTitle(title)}
+				{metas.map(meta => DocHead.addMeta(meta))}
+				{links.map(link => DocHead.addLink(link))}
+			</div>
+		);
+	}
+}
+
+HeadTags.propTypes = {
+	url: React.PropTypes.string,
+	title: React.PropTypes.string,
+	description: React.PropTypes.string,
+	image: React.PropTypes.string,
 };
 
 module.exports = HeadTags;
+export default HeadTags;

--- a/packages/nova-base-components/lib/common/HeadTags.jsx
+++ b/packages/nova-base-components/lib/common/HeadTags.jsx
@@ -12,6 +12,8 @@ class HeadTags extends Component {
 		const metas = [
 			{charset: "utf-8"},
 			{name: "description", content: description},
+			// responsive
+			{name: "viewport", content:"width=device-width, initial-scale=1"},
 			// facebook
 			{property: "og:type", content: "article"},
 			{property: "og:url", content: url},

--- a/packages/nova-base-components/lib/common/Header.jsx
+++ b/packages/nova-base-components/lib/common/Header.jsx
@@ -10,7 +10,7 @@ const ListContainer = SmartContainers.ListContainer;
 
 const Header = ({currentUser}) => {
   
-  ({Logo, CategoriesList, NewPostButton, UserMenu, AccountsMenu, HeadTags} = Telescope.components);
+  ({Logo, CategoriesList, NewPostButton, UserMenu, AccountsMenu} = Telescope.components);
 
   const logoUrl = Telescope.settings.get("logoUrl");
   const siteTitle = Telescope.settings.get("title", "Telescope");
@@ -18,8 +18,6 @@ const Header = ({currentUser}) => {
 
   return (
     <div className="header-wrapper">
-
-      {/*<HeadTags url={Telescope.utils.getSiteUrl()} title={siteTitle} description={tagline} image={logoUrl} />*/}
 
       <header className="header">
 

--- a/packages/nova-base-components/lib/posts/PostPage.jsx
+++ b/packages/nova-base-components/lib/posts/PostPage.jsx
@@ -16,7 +16,7 @@ const PostPage = ({document, currentUser}) => {
   return (
     <div className="post-page">
 
-      {/*<HeadTags url={Posts.getLink(post)} title={post.title}/>*/}
+      <HeadTags url={Posts.getLink(post)} title={post.title} image={post.thumbnailUrl} />
       
       <PostItem post={post}/>
 

--- a/packages/nova-base-components/lib/posts/list/PostListHeader.jsx
+++ b/packages/nova-base-components/lib/posts/list/PostListHeader.jsx
@@ -5,10 +5,11 @@ const ListContainer = SmartContainers.ListContainer;
 
 const PostListHeader = () => {
 
-  ({PostViews, SearchForm, CategoriesList} = Telescope.components)
+  ({PostViews, SearchForm, CategoriesList, HeadTags} = Telescope.components)
 
   return (
     <div className="post-list-header">
+      <HeadTags />
       <div className="post-list-categories">
         <ListContainer collection={Categories} limit={0} resultsPropName="categories" component={CategoriesList}/>
       </div>

--- a/packages/nova-base-components/lib/users/UserProfile.jsx
+++ b/packages/nova-base-components/lib/users/UserProfile.jsx
@@ -1,8 +1,12 @@
 import React, { PropTypes, Component } from 'react';
 
 const UserProfile = ({user, currentUser}) => {
+
+  ({HeadTags} = Telescope.components);
+
   return (
     <div className="page user-profile">
+      <HeadTags url={Users.getProfileUrl(user, true)} title={Users.getDisplayName(user)} description={user.telescope.bio} />
       <h2>{Users.getDisplayName(user)}</h2>
       <p>{user.telescope.bio}</p>
       <ul>

--- a/packages/nova-base-components/package.js
+++ b/packages/nova-base-components/package.js
@@ -27,7 +27,8 @@ Package.onUse(function (api) {
     // 'std:accounts-ui-basic@1.0.1',
     'std:accounts-ui@1.1.12',
     'dburles:spacebars-tohtml@1.0.1',
-    'utilities:react-list-container'
+    'utilities:react-list-container',
+    'kadira:dochead@1.4.0'
   ]);
 
   api.addFiles([


### PR DESCRIPTION
Well, seems to work better with dochead than react-helmet @SachaG :)

I wrapped the rendering in a component as recommended by the doc in order to have SSR.

The component accept props, which by default are set to the general information of the Telescope.

I removed the old one from `Header` and placed it in 3 places :
1. `PostPage` container to have access to post props.
2. `PostListHeader` which is displayed on "basic view".
3. `UserProfile` component to have access to a user data.

What do you think of the "placement"?

I'm thinking about using new utils/helpers like `Telescope.utils.getLogoUrl()` instead of `Telescope.utils.getSiteUrl() + Telescope.settings.get("logoUrl"); ` and `Posts.getPostThumbnailUrl()` instead of `post.thumbnailUrl`. It would give a shorthand for access absolute url to logo and postThumbnail (maybe get it from embedly if active?).