### PR TITLE
Fix HeadTags <-> Flexbox + add 2 helpers for images

### DIFF
--- a/packages/nova-base-components/lib/posts/list/PostListHeader.jsx
+++ b/packages/nova-base-components/lib/posts/list/PostListHeader.jsx
@@ -8,13 +8,15 @@ const PostListHeader = () => {
   ({PostViews, SearchForm, CategoriesList, HeadTags} = Telescope.components)
 
   return (
-    <div className="post-list-header">
+    <div>
       <HeadTags />
-      <div className="post-list-categories">
-        <ListContainer collection={Categories} limit={0} resultsPropName="categories" component={CategoriesList}/>
+      <div className="post-list-header">
+        <div className="post-list-categories">
+          <ListContainer collection={Categories} limit={0} resultsPropName="categories" component={CategoriesList}/>
+        </div>
+        <PostViews />
+        <SearchForm/>
       </div>
-      <PostViews />
-      <SearchForm/>
     </div>
   )
 }

--- a/packages/nova-base-components/lib/posts/list/PostThumbnail.jsx
+++ b/packages/nova-base-components/lib/posts/list/PostThumbnail.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 const PostThumbnail = ({post}) => {
   return (
     <a className="post-thumbnail" href={Posts.getLink(post)} target={Posts.getLinkTarget(post)}>
-      <img src={post.thumbnailUrl} />
+      <img src={Posts.getThumbnailUrl(post)} />
     </a>
   )
 }

--- a/packages/nova-lib/lib/utils.js
+++ b/packages/nova-lib/lib/utils.js
@@ -318,3 +318,12 @@ Telescope.utils.getFieldLabel = (fieldName, collection) => {
   const nameWithSpaces = Telescope.utils.camelToSpaces(fieldName.replace("telescope.", ""));
   return label || nameWithSpaces;
 }
+
+Telescope.utils.getLogoUrl = () => {
+  const logoUrl = Telescope.settings.get("logoUrl");
+  if (!!logoUrl) {
+    const prefix = Telescope.utils.getSiteUrl().slice(0,-1);
+    // the logo may be hosted on another website
+    return logoUrl.indexOf('://') > -1 ? logoUrl : prefix + logoUrl;
+  }
+};

--- a/packages/nova-posts/lib/helpers.js
+++ b/packages/nova-posts/lib/helpers.js
@@ -143,3 +143,13 @@ Posts.getNotificationProperties = function (post) {
 
   return properties;
 };
+
+Posts.getThumbnailUrl = (post) => {
+  const thumbnailUrl = post.thumbnailUrl;
+  if (!!thumbnailUrl) {
+    const prefix = Telescope.utils.getSiteUrl().slice(0,-1);
+    // the thumbnail may be hosted on another website
+    return thumbnailUrl.indexOf('://') > -1 ? thumbnailUrl : prefix + thumbnailUrl;
+  }
+};
+Posts.helpers({ getThumbnailUrl() { return Posts.getThumbnailUrl(this); } });


### PR DESCRIPTION
I put HeadTags outside the `post-header-list` div in order to not mess with Flexbox :+1: 

And I created the two helpers `Telescope.utils.getLogoUrl()` which returns the logo url & `Posts.getThumbnailUrl(post)` which returns the thumbnail url.