### PR TITLE
Helper: handle thumbnails from embedly, an external website or hosted on the app

### DIFF
--- a/packages/nova-posts/lib/helpers.js
+++ b/packages/nova-posts/lib/helpers.js
@@ -144,12 +144,14 @@ Posts.getNotificationProperties = function (post) {
   return properties;
 };
 
+/**
+ * @summary Get the complete thumbnail url whether it is hosted on Embedly or on an external website, or locally in the app.
+ * @param {Object} post
+ */
 Posts.getThumbnailUrl = (post) => {
   const thumbnailUrl = post.thumbnailUrl;
   if (!!thumbnailUrl) {
-    const prefix = Telescope.utils.getSiteUrl().slice(0,-1);
-    // the thumbnail may be hosted on another website
-    return thumbnailUrl.indexOf('://') > -1 ? thumbnailUrl : prefix + thumbnailUrl;
+    return thumbnailUrl.indexOf('//') > -1 ? Telescope.utils.addHttp(thumbnailUrl) : Telescope.utils.getSiteUrl().slice(0,-1) + thumbnailUrl;
   }
 };
 Posts.helpers({ getThumbnailUrl() { return Posts.getThumbnailUrl(this); } });


### PR DESCRIPTION
Watch for double slashes in the `thumbnailUrl`, if they exist: use `Telescope.utils.addHttp` to add the missing http:// if needed!

Repairs https://github.com/TelescopeJS/Telescope/pull/1292#issuecomment-208159305