### PR TITLE
Move head tags to layout

### DIFF
--- a/packages/nova-base-components/lib/common/HeadTags.jsx
+++ b/packages/nova-base-components/lib/common/HeadTags.jsx
@@ -4,39 +4,43 @@ import { DocHead } from 'meteor/kadira:dochead';
 class HeadTags extends Component {
 	render() {
 
+		if (!!this.props) {
+			DocHead.removeDocHeadAddedTags();
+		}
+
 		const url = this.props.url ? this.props.url : Telescope.utils.getSiteUrl();
 		const title = this.props.title ? this.props.title : Telescope.settings.get("title");
 		const description = this.props.description ? this.props.description : Telescope.settings.get("tagline");
 		const image = this.props.image ? this.props.image : Telescope.utils.getSiteUrl() + Telescope.settings.get("logoUrl");
 
 		const metas = [
-			{charset: "utf-8"},
-			{name: "description", content: description},
+			{ charset: "utf-8" },
+			{ name: "description", content: description },
 			// responsive
-			{name: "viewport", content:"width=device-width, initial-scale=1"},
+			{ name: "viewport", content:"width=device-width, initial-scale=1" },
 			// facebook
-			{property: "og:type", content: "article"},
-			{property: "og:url", content: url},
-			{property: "og:image", content: image},
-			{property: "og:title", content: title},
-			{property: "og:description", content: description},
+			{ property: "og:type", content: "article" },
+			{ property: "og:url", content: url },
+			{ property: "og:image", content: image },
+			{ property: "og:title", content: title },
+			{ property: "og:description", content: description },
 			//twitter
-			{name: "twitter:card", content: "summary"},
-			{name: "twitter:image:src", content: image},
-			{name: "twitter:title", content: title},
-			{name: "twitter:description", content: description}
+			{ name: "twitter:card", content: "summary" },
+			{ name: "twitter:image:src", content: image },
+			{ name: "twitter:title", content: title },
+			{ name: "twitter:description", content: description }
 		];
 
 		const links = [
-			{rel: "canonical", href: Telescope.utils.getSiteUrl()},
-			{rel: "shortcut icon", href: Telescope.settings.get("favicon", "/img/favicon.ico")}
+			{ rel: "canonical", href: Telescope.utils.getSiteUrl() },
+			{ rel: "shortcut icon", href: Telescope.settings.get("favicon", "/img/favicon.ico") }
 		];
 
 		return (
 			<div>
-				{DocHead.setTitle(title)}
-				{metas.map(meta => DocHead.addMeta(meta))}
-				{links.map(link => DocHead.addLink(link))}
+				{ DocHead.setTitle(title) }
+				{ metas.map(meta => DocHead.addMeta(meta)) }
+				{ links.map(link => DocHead.addLink(link)) }
 			</div>
 		);
 	}

--- a/packages/nova-base-components/lib/common/HeadTags.jsx
+++ b/packages/nova-base-components/lib/common/HeadTags.jsx
@@ -3,10 +3,7 @@ import { DocHead } from 'meteor/kadira:dochead';
 
 class HeadTags extends Component {
 	render() {
-
-		if (!!this.props) {
-			DocHead.removeDocHeadAddedTags();
-		}
+		DocHead.removeDocHeadAddedTags();
 
 		const url = this.props.url ? this.props.url : Telescope.utils.getSiteUrl();
 		const title = this.props.title ? this.props.title : Telescope.settings.get("title");

--- a/packages/nova-base-components/lib/common/Layout.jsx
+++ b/packages/nova-base-components/lib/common/Layout.jsx
@@ -5,10 +5,12 @@ const FlashContainer = Core.FlashContainer;
 
 const Layout = props => {
 
-  ({Header, Footer, FlashMessages, NewsletterForm} = Telescope.components);
+  ({Header, Footer, FlashMessages, NewsletterForm, HeadTags} = Telescope.components);
 
   return (
     <div className="wrapper" id="wrapper">
+
+      <HeadTags />
 
       <Header {...props}/>
     

--- a/packages/nova-base-components/lib/posts/list/PostListHeader.jsx
+++ b/packages/nova-base-components/lib/posts/list/PostListHeader.jsx
@@ -5,11 +5,10 @@ const ListContainer = SmartContainers.ListContainer;
 
 const PostListHeader = () => {
 
-  ({PostViews, SearchForm, CategoriesList, HeadTags} = Telescope.components)
+  ({PostViews, SearchForm, CategoriesList} = Telescope.components)
 
   return (
     <div>
-      <HeadTags />
       <div className="post-list-header">
         <div className="post-list-categories">
           <ListContainer collection={Categories} limit={0} resultsPropName="categories" component={CategoriesList}/>


### PR DESCRIPTION
It will also remove older added tags on the client, so there are no meta tags duplication: see https://github.com/kadirahq/meteor-dochead/#docheadremovedocheadaddedtags.