### PR TITLE
Completed profile hook

### DIFF
--- a/packages/nova-base-components/lib/common/Layout.jsx
+++ b/packages/nova-base-components/lib/common/Layout.jsx
@@ -5,12 +5,14 @@ const FlashContainer = Core.FlashContainer;
 
 const Layout = props => {
 
-  ({Header, Footer, FlashMessages, NewsletterForm, HeadTags} = Telescope.components);
+  ({Header, Footer, FlashMessages, NewsletterForm, HeadTags, UserProfileCheck} = Telescope.components);
 
   return (
     <div className="wrapper" id="wrapper">
 
       <HeadTags />
+
+      <UserProfileCheck {...props} />
 
       <Header {...props}/>
     

--- a/packages/nova-base-components/lib/components.js
+++ b/packages/nova-base-components/lib/components.js
@@ -65,6 +65,7 @@ Telescope.registerComponent("CanEditUser",          require('./permissions/CanEd
 
 Telescope.registerComponent("UserEdit",             require('./users/UserEdit.jsx'));
 Telescope.registerComponent("UserProfile",          require('./users/UserProfile.jsx'));
+Telescope.registerComponent("UserProfileCheck",     require('./users/UserProfileCheck.jsx'));
 Telescope.registerComponent("UserAvatar",           require('./users/UserAvatar.jsx'));
 Telescope.registerComponent("UserName",             require('./users/UserName.jsx'));
 Telescope.registerComponent("UserMenu",             require('./users/UserMenu.jsx'));

--- a/packages/nova-base-components/lib/users/UserProfileCheck.jsx
+++ b/packages/nova-base-components/lib/users/UserProfileCheck.jsx
@@ -17,7 +17,7 @@ const UserProfileCheck = ({ currentUser }) => {
           methodName="users.edit"
           labelFunction={ (fieldName)=>Telescope.utils.getFieldLabel(fieldName, Meteor.users) }
           successCallback={ (user)=> Telescope.callbacks.runAsync("profileCompletedAsync", user) }
-          requiredFieldsOnly={ true }
+          fields={ ["telescope.email"] }
         />
       </Modal.Body>
       <Button bsStyle="primary" className="complete-profile-logout" onClick={ () => Meteor.logout() }>Log Out</Button>

--- a/packages/nova-base-components/lib/users/UserProfileCheck.jsx
+++ b/packages/nova-base-components/lib/users/UserProfileCheck.jsx
@@ -1,0 +1,27 @@
+import React, { PropTypes, Component } from 'react';
+import { Modal } from 'react-bootstrap';
+
+import NovaForm from "meteor/nova:forms";
+
+const UserProfileCheck = ({ currentUser }) => {
+  return currentUser && !Users.hasCompletedProfile(currentUser) ?
+    (<Modal bsSize='large' show={ true }>
+      <Modal.Header closeButton>
+        <Modal.Title>Complete your Profile</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <NovaForm
+          currentUser={ currentUser }
+          collection={ Meteor.users }
+          document={ currentUser }
+          methodName="users.edit"
+          labelFunction={(fieldName)=>Telescope.utils.getFieldLabel(fieldName, Meteor.users)}
+          successCallback={ (user)=> Telescope.callbacks.runAsync("profileCompletedAsync", user) }
+        />
+      </Modal.Body>
+    </Modal>)
+    : (null);
+};
+
+module.exports = UserProfileCheck;
+export default UserProfileCheck;

--- a/packages/nova-base-components/lib/users/UserProfileCheck.jsx
+++ b/packages/nova-base-components/lib/users/UserProfileCheck.jsx
@@ -17,6 +17,7 @@ const UserProfileCheck = ({ currentUser }) => {
           methodName="users.edit"
           labelFunction={(fieldName)=>Telescope.utils.getFieldLabel(fieldName, Meteor.users)}
           successCallback={ (user)=> Telescope.callbacks.runAsync("profileCompletedAsync", user) }
+          requiredFieldsOnly={ true }
         />
       </Modal.Body>
     </Modal>)

--- a/packages/nova-base-components/lib/users/UserProfileCheck.jsx
+++ b/packages/nova-base-components/lib/users/UserProfileCheck.jsx
@@ -1,29 +1,40 @@
 import React, { PropTypes, Component } from 'react';
+import { composeWithTracker } from 'react-komposer';
 import { Button, Modal } from 'react-bootstrap';
+import Router from '../router.js';
 
 import NovaForm from "meteor/nova:forms";
 
-const UserProfileCheck = ({ currentUser }) => {
-  return currentUser && !Users.hasCompletedProfile(currentUser) ?
-    (<Modal bsSize='large' show={ true }>
-      <Modal.Header>
-        <Modal.Title>Complete your Profile</Modal.Title>
-      </Modal.Header>
-      <Modal.Body>
-        <NovaForm
-          currentUser={ currentUser }
-          collection={ Meteor.users }
-          document={ currentUser }
-          methodName="users.edit"
-          labelFunction={ (fieldName)=>Telescope.utils.getFieldLabel(fieldName, Meteor.users) }
-          successCallback={ (user)=> Telescope.callbacks.runAsync("profileCompletedAsync", user) }
-          fields={ ["telescope.email"] }
-        />
-      </Modal.Body>
-      <Button bsStyle="primary" className="complete-profile-logout" onClick={ () => Meteor.logout() }>Log Out</Button>
-    </Modal>)
-    : (null);
+function composerUserProfileCheck(props, onData) {
+  const currentUser = props.currentUser;
+  const show = currentUser && !Users.hasCompletedProfile(currentUser) ? true : false; // force a bool value
+  onData(null, { currentUser, show });
+}
+
+const UserProfileCheckModal = ({currentUser, show}) => {
+    return !!currentUser ?
+      (
+        <Modal bsSize='small' show={ show }>
+          <Modal.Header>
+            <Modal.Title>Complete your Profile</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            <NovaForm
+              currentUser={ currentUser }
+              collection={ Meteor.users }
+              document={ currentUser }
+              methodName="users.edit"
+              labelFunction={ (fieldName)=>Telescope.utils.getFieldLabel(fieldName, Meteor.users) }
+              successCallback={ (user) => Telescope.callbacks.runAsync("profileCompletedAsync", user) }
+              fields={ ["telescope.email"] }
+            />
+          </Modal.Body>
+          <Button bsStyle="primary" className="complete-profile-logout" onClick={ () => Meteor.logout(() => Router.go('/')) }>Log Out</Button>
+        </Modal>
+      ) : (null);
 };
+
+const UserProfileCheck = composeWithTracker(composerUserProfileCheck)(UserProfileCheckModal);
 
 module.exports = UserProfileCheck;
 export default UserProfileCheck;

--- a/packages/nova-base-components/lib/users/UserProfileCheck.jsx
+++ b/packages/nova-base-components/lib/users/UserProfileCheck.jsx
@@ -1,12 +1,12 @@
 import React, { PropTypes, Component } from 'react';
-import { Modal } from 'react-bootstrap';
+import { Button, Modal } from 'react-bootstrap';
 
 import NovaForm from "meteor/nova:forms";
 
 const UserProfileCheck = ({ currentUser }) => {
   return currentUser && !Users.hasCompletedProfile(currentUser) ?
     (<Modal bsSize='large' show={ true }>
-      <Modal.Header closeButton>
+      <Modal.Header>
         <Modal.Title>Complete your Profile</Modal.Title>
       </Modal.Header>
       <Modal.Body>
@@ -15,11 +15,12 @@ const UserProfileCheck = ({ currentUser }) => {
           collection={ Meteor.users }
           document={ currentUser }
           methodName="users.edit"
-          labelFunction={(fieldName)=>Telescope.utils.getFieldLabel(fieldName, Meteor.users)}
+          labelFunction={ (fieldName)=>Telescope.utils.getFieldLabel(fieldName, Meteor.users) }
           successCallback={ (user)=> Telescope.callbacks.runAsync("profileCompletedAsync", user) }
           requiredFieldsOnly={ true }
         />
       </Modal.Body>
+      <Button bsStyle="primary" className="complete-profile-logout" onClick={ () => Meteor.logout() }>Log Out</Button>
     </Modal>)
     : (null);
 };

--- a/packages/nova-base-styles/lib/stylesheets/_users.scss
+++ b/packages/nova-base-styles/lib/stylesheets/_users.scss
@@ -1,0 +1,6 @@
+.complete-profile-logout {
+  position: absolute;
+  left: 130px;
+  bottom: 0;
+  margin-bottom: 15px;
+}

--- a/packages/nova-base-styles/lib/stylesheets/_users.scss
+++ b/packages/nova-base-styles/lib/stylesheets/_users.scss
@@ -1,6 +1,6 @@
 .complete-profile-logout {
   position: absolute;
-  left: 130px;
+  left: 115px;
   bottom: 0;
   margin-bottom: 15px;
 }

--- a/packages/nova-base-styles/lib/stylesheets/main.scss
+++ b/packages/nova-base-styles/lib/stylesheets/main.scss
@@ -13,6 +13,7 @@
 @import "newsletter";
 @import "other";
 @import "posts";
+@import "users";
 
 body{
   color: $black;

--- a/packages/nova-forms/lib/FormComponent.jsx
+++ b/packages/nova-forms/lib/FormComponent.jsx
@@ -55,7 +55,7 @@ FormComponent.propTypes = {
   value: React.PropTypes.any, 
   options: React.PropTypes.any,
   control: React.PropTypes.any,
-  dataType: React.PropTypes.any,
+  datatype: React.PropTypes.any,
   disabled: React.PropTypes.bool
 }
 

--- a/packages/nova-forms/lib/NovaForm.jsx
+++ b/packages/nova-forms/lib/NovaForm.jsx
@@ -48,9 +48,18 @@ class NovaForm extends Component{
   }
 
   // get relevant fields
-  getFieldNames() { 
+  getFieldNames() {
     const collection = this.props.collection;
-    const fields = this.getFormType() === "edit" ? collection.getEditableFields(this.props.currentUser, this.getDocument()) : collection.getInsertableFields(this.props.currentUser);
+    let fields = this.getFormType() === "edit" ? collection.getEditableFields(this.props.currentUser, this.getDocument()) : collection.getInsertableFields(this.props.currentUser);
+
+    if (this.props.requiredFieldsOnly) {
+      const schema = collection.simpleSchema()._schema;
+      fields = _.filter(_.keys(schema), function (fieldName) {
+        const field = schema[fieldName];
+        return !!field.required;
+      });
+    }
+
     return fields;
   }
 
@@ -273,7 +282,8 @@ NovaForm.propTypes = {
   labelFunction: React.PropTypes.func,
   prefilledProps: React.PropTypes.object,
   layout: React.PropTypes.string,
-  cancelCallback: React.PropTypes.func
+  cancelCallback: React.PropTypes.func,
+  requiredFieldsOnly: React.PropTypes.bool
 }
 
 NovaForm.defaultPropTypes = {

--- a/packages/nova-forms/lib/NovaForm.jsx
+++ b/packages/nova-forms/lib/NovaForm.jsx
@@ -53,18 +53,18 @@ class NovaForm extends Component{
 
   // get relevant fields
   getFieldNames() {
-    const collection = this.props.collection;
-    let fields = this.getFormType() === "edit" ? collection.getEditableFields(this.props.currentUser, this.getDocument()) : collection.getInsertableFields(this.props.currentUser);
+    const { collection, fields } = this.props;
+    let relevantFields = this.getFormType() === "edit" ? collection.getEditableFields(this.props.currentUser, this.getDocument()) : collection.getInsertableFields(this.props.currentUser);
 
-    if (this.props.requiredFieldsOnly) {
+    // some specific fields are required, filter on them
+    if (typeof fields !== "undefined" && fields.length > 0) {
       const schema = collection.simpleSchema()._schema;
-      fields = _.filter(_.keys(schema), function (fieldName) {
-        const field = schema[fieldName];
-        return !!field.required;
+      relevantFields = _.filter(_.keys(schema), function (fieldName) {
+        return _.contains(fields, fieldName);
       });
     }
 
-    return fields;
+    return relevantFields;
   }
 
   // look in the document, prefilled values, or inputted values
@@ -296,7 +296,7 @@ NovaForm.propTypes = {
   prefilledProps: React.PropTypes.object,
   layout: React.PropTypes.string,
   cancelCallback: React.PropTypes.func,
-  requiredFieldsOnly: React.PropTypes.bool
+  fields: React.PropTypes.arrayOf(React.PropTypes.string)
 }
 
 NovaForm.defaultPropTypes = {

--- a/packages/nova-forms/lib/NovaForm.jsx
+++ b/packages/nova-forms/lib/NovaForm.jsx
@@ -235,7 +235,7 @@ class NovaForm extends Component{
       let field = {
         name: fieldName,
         label: (typeof this.props.labelFunction === "function") ? this.props.labelFunction(fieldName) : fieldName,
-        dataType: fieldSchema.type,
+        datatype: fieldSchema.type,
         control: fieldSchema.control,
         layout: this.props.layout
       }

--- a/packages/nova-lib/lib/settings.js
+++ b/packages/nova-lib/lib/settings.js
@@ -22,7 +22,7 @@ Telescope.settings.get = function (setting, defaultValue) {
 
   const collection = Telescope.settings.collection;
 
-  if (Telescope.settings.getFromJSON(setting) !== "undefined") { // if on the server, look in Meteor.settings
+  if (typeof Telescope.settings.getFromJSON(setting) !== "undefined") { // if on the server, look in Meteor.settings
 
     return Telescope.settings.getFromJSON(setting);
 


### PR DESCRIPTION
Reactively show a modal if the profile required fields are not completed. 

The only way to close this modal is to complete the fields or log out with the button provided.

I have used `nova:forms` + `users.edit` method and add a prop `requiredFieldsOnly` to show only `telescope.email`.