### PR TITLE
Complete soft delete feature for comments (Revision 2)

### DIFF
--- a/packages/nova-base-components/lib/comments/CommentsItem.jsx
+++ b/packages/nova-base-components/lib/comments/CommentsItem.jsx
@@ -4,7 +4,7 @@ class CommentsItem extends Component{
 
   constructor() {
     super();
-    ['showReply', 'replyCancelCallback', 'replySuccessCallback', 'showEdit', 'editCancelCallback', 'editSuccessCallback'].forEach(methodName => {this[methodName] = this[methodName].bind(this)});
+    ['showReply', 'replyCancelCallback', 'replySuccessCallback', 'showEdit', 'editCancelCallback', 'editSuccessCallback', 'deleteComment'].forEach(methodName => {this[methodName] = this[methodName].bind(this)});
     this.state = {
       showReply: false,
       showEdit: false
@@ -39,13 +39,23 @@ class CommentsItem extends Component{
     this.setState({showEdit: false});
   }
 
+  deleteComment() {
+    const comment = this.props.comment;
+    if (window.confirm(`Delete comment “${comment.body}”?`)) {
+      Meteor.call('comments.deleteById', comment._id, (error, result) => {
+       Messages.flash(`Comment “${comment.body}” deleted.`, "success");
+       Events.track("comment deleted", {'_id': comment._id});
+      });
+    }
+  }
+
   renderComment() {
     const htmlBody = {__html: this.props.comment.htmlBody};
 
     return (
       <div className="comments-item-text">
         <div dangerouslySetInnerHTML={htmlBody}></div>
-        <a className="comments-item-reply-link" onClick={this.showReply}><Icon name="reply"/> Reply</a>
+        {!this.props.comment.isDeleted ? <a className="comments-item-reply-link" onClick={this.showReply}><Icon name="reply"/> Reply</a> : null} 
       </div>  
     )
   }
@@ -94,6 +104,7 @@ class CommentsItem extends Component{
             <UsersName user={comment.user}/>
             <div className="comments-item-date">{moment(comment.postedAt).fromNow()}</div>
             {Users.can.edit(this.props.currentUser, this.props.comment) ? <a className="comment-edit" onClick={this.showEdit}>Edit</a> : null}
+            {Users.can.edit(this.props.currentUser, this.props.comment) ? <a className="comment-delete" onClick={this.deleteComment}>Delete</a> : null}
           </div>
           {this.state.showEdit ? this.renderEdit() : this.renderComment()}
         </div>

--- a/packages/nova-base-styles/lib/stylesheets/_comments.scss
+++ b/packages/nova-base-styles/lib/stylesheets/_comments.scss
@@ -42,8 +42,11 @@
     color: $medium-text;
     font-size: $small-font;
   }
-  .comment-edit{
+  .comment-edit, .comment-delete {
     font-size: $small-font;
+  }
+  .comment-delete {
+    margin-left: 8px;
   }
 }
 

--- a/packages/nova-users/lib/permissions.js
+++ b/packages/nova-users/lib/permissions.js
@@ -126,6 +126,8 @@ Users.can.edit = function (user, document) {
     return false;
   }
 
+  if (document.hasOwnProperty('isDeleted') && document.isDeleted) return false;
+
   var adminCheck = Users.is.admin(user);
   var ownerCheck = Users.is.owner(user, document);
 


### PR DESCRIPTION
This follows the same functionality and style of deleting posts, no use of NovaForm, direct call.

- Add deleteComment function to CommentsItem.jsx
- Add Delete link next to Edit link in CommentsItem.jsx
- Hide reply link if comment.isDeleted
- Add styling for Delete link element in _comments.scss
- Add check for document.isDeleted in Users.can.edit in permissions.js