### PR TITLE
Load categories at startup in load_categories.js

### DIFF
--- a/packages/nova-categories/lib/server/load_categories.js
+++ b/packages/nova-categories/lib/server/load_categories.js
@@ -1,19 +1,22 @@
 // Load categories from settings, if there are any
 
-if (Meteor.settings && Meteor.settings.categories) {
-  Meteor.settings.categories.forEach(category => {
-
-    // look for existing category with same slug
-    let existingCategory = Categories.findOne({slug: category.slug});
-
-    if (existingCategory) {
-      // if category exists, update it with settings data except slug
-      delete category.slug;
-      Categories.update(existingCategory._id, {$set: category});
-    } else {
-      // if not, create it
-      Categories.insert(category);
-      console.log(`// Creating category “${category.name}”`);
-    }
-  });
-}
+// Loading at startup allows inserting categories with extended schema
+Meteor.startup(() => {
+  if (Meteor.settings && Meteor.settings.categories) {
+    Meteor.settings.categories.forEach(category => {
+  
+      // look for existing category with same slug
+      let existingCategory = Categories.findOne({slug: category.slug});
+  
+      if (existingCategory) {
+        // if category exists, update it with settings data except slug
+        delete category.slug;
+        Categories.update(existingCategory._id, {$set: category});
+      } else {
+        // if not, create it
+        Categories.insert(category);
+        console.log(`// Creating category “${category.name}”`);
+      }
+    });
+  }
+});


### PR DESCRIPTION
Loading categories inside Meteor.startup() allows inserting categories from settings.json with an extended schema (extended with Categories.addField()).