### PR TITLE
Fixes

### DIFF
--- a/packages/nova-base-components/lib/categories/CategoriesList.jsx
+++ b/packages/nova-base-components/lib/categories/CategoriesList.jsx
@@ -41,7 +41,7 @@ class CategoriesList extends Component {
           <Modal.Title><FormattedMessage id="categories.edit"/></Modal.Title>
         </Modal.Header>        
         <Modal.Body>
-          <ContextPasser currentUser={this.context.currentUser} closeCallback={this.closeModal}>
+          <ContextPasser currentUser={this.context.currentUser} messages={this.context.messages} closeCallback={this.closeModal}>
             <Telescope.components.CategoriesEditForm category={category}/>
           </ContextPasser>
         </Modal.Body>
@@ -57,7 +57,7 @@ class CategoriesList extends Component {
           <Modal.Title><FormattedMessage id="categories.new"/></Modal.Title>
         </Modal.Header>        
         <Modal.Body>
-          <ContextPasser currentUser={this.context.currentUser} closeCallback={this.closeModal}>
+          <ContextPasser currentUser={this.context.currentUser} messages={this.context.messages} closeCallback={this.closeModal}>
             <Telescope.components.CategoriesNewForm/>
           </ContextPasser>
         </Modal.Body>
@@ -116,7 +116,8 @@ CategoriesList.propTypes = {
 }
 
 CategoriesList.contextTypes = {
-  currentUser: React.PropTypes.object
+  currentUser: React.PropTypes.object,
+  messages: React.PropTypes.object,
 };
 
 module.exports = withRouter(CategoriesList);

--- a/packages/nova-base-components/lib/categories/CategoriesNewForm.jsx
+++ b/packages/nova-base-components/lib/categories/CategoriesNewForm.jsx
@@ -11,7 +11,7 @@ const CategoriesNewForm = (props, context) => {
         currentUser={context.currentUser}
         methodName="categories.new"
         successCallback={(category)=>{
-          this.context.messages.flash("Category created.", "success");
+          context.messages.flash("Category created.", "success");
         }}
       />
     </div>

--- a/packages/nova-base-components/lib/common/App.jsx
+++ b/packages/nova-base-components/lib/common/App.jsx
@@ -17,7 +17,7 @@ class App extends Component {
 
     return {
       currentUser: this.props.currentUser,
-      applyAction: this.props.applyAction,
+      actions: this.props.actions,
       events: this.props.events,
       messages: this.props.messages,
       intl: intl
@@ -42,11 +42,14 @@ class App extends Component {
 App.propTypes = {
   ready: React.PropTypes.bool,
   currentUser: React.PropTypes.object,
+  actions: React.PropTypes.object,
+  events: React.PropTypes.object,
+  messages: React.PropTypes.object,
 }
 
 App.childContextTypes = {
   currentUser: React.PropTypes.object,
-  applyAction: React.PropTypes.object,
+  actions: React.PropTypes.object,
   events: React.PropTypes.object,
   messages: React.PropTypes.object,
   intl: intlShape

--- a/packages/nova-base-components/lib/users/UsersMenu.jsx
+++ b/packages/nova-base-components/lib/users/UsersMenu.jsx
@@ -74,5 +74,9 @@ UsersMenu.propTypes = {
   user: React.PropTypes.object
 }
 
+UsersMenu.contextTypes = {
+  messages: React.PropTypes.object
+}
+
 module.exports = UsersMenu;
 export default UsersMenu;

--- a/packages/nova-base-components/lib/users/UsersMenu.jsx
+++ b/packages/nova-base-components/lib/users/UsersMenu.jsx
@@ -33,7 +33,7 @@ class UsersMenu extends Component {
           <Modal.Title><FormattedMessage id="settings.edit"/></Modal.Title>
         </Modal.Header>        
         <Modal.Body>
-          <ContextPasser currentUser={this.props.user} closeCallback={this.closeModal}>
+          <ContextPasser currentUser={this.props.user} messages={this.context.messages} closeCallback={this.closeModal}>
             <SettingsEditForm/>
           </ContextPasser>
         </Modal.Body>

--- a/packages/nova-core/lib/components/ContextPasser.jsx
+++ b/packages/nova-core/lib/components/ContextPasser.jsx
@@ -5,7 +5,10 @@ class ContextPasser extends Component {
   getChildContext() {
     return {
       closeCallback: this.props.closeCallback,
-      currentUser: this.props.currentUser // pass on currentUser
+      currentUser: this.props.currentUser, // pass on currentUser,
+      actions: this.props.actions,
+      events: this.props.events,
+      messages: this.props.messages,
     };
   }
 
@@ -16,12 +19,18 @@ class ContextPasser extends Component {
 
 ContextPasser.propTypes = {
   closeCallback: React.PropTypes.func,
-  currentUser: React.PropTypes.object
+  currentUser: React.PropTypes.object,
+  actions: React.PropTypes.object,
+  events: React.PropTypes.object,
+  messages: React.PropTypes.object,  
 };
 
 ContextPasser.childContextTypes = {
   closeCallback: React.PropTypes.func,
-  currentUser: React.PropTypes.object
+  currentUser: React.PropTypes.object,
+  actions: React.PropTypes.object,
+  events: React.PropTypes.object,
+  messages: React.PropTypes.object,
 };
 
 export default ContextPasser;

--- a/packages/nova-core/lib/containers/AppComposer.jsx
+++ b/packages/nova-core/lib/containers/AppComposer.jsx
@@ -1,5 +1,5 @@
 import { composeWithTracker } from 'react-komposer';
-import { Messages } from '../messages.js';
+import Messages from '../messages.js';
 
 function composer(props, onData) {
 

--- a/packages/nova-i18n-en-us/lib/en_US.js
+++ b/packages/nova-i18n-en-us/lib/en_US.js
@@ -102,6 +102,10 @@ Telescope.strings.en = {
   "settings.facebookPage": "Facebook Page",
   "settings.googleAnalyticsId": "Google Analytics ID",
   "settings.locale": "Locale",
+  "settings.requireViewInvite": "Require View Invite",
+  "settings.requirePostInvite": "Require Post Invite",
+  "settings.requirePostsApproval": "Require Posts Approval",
+  "settings.scoreUpdateInterval": "Score Update Interval",
   
   "app.loading": "Loading…",
   "app.404": "Sorry, we couldn't find what you were looking for.",

--- a/packages/nova-newsletter/lib/callbacks.js
+++ b/packages/nova-newsletter/lib/callbacks.js
@@ -1,6 +1,6 @@
 function subscribeUserOnProfileCompletion (user) {
   if (!!Telescope.settings.get('autoSubscribe') && !!Users.getEmail(user)) {
-    addToMailChimpList(user, false, function (error, result) {
+    MailChimpList.add(user, false, function (error, result) {
       console.log(error);
       console.log(result);
     });


### PR DESCRIPTION
Hi 👋 

Some fixes on context passing which were blocking actions like editing / adding new categories and upvoting (3 commits):
* default export for Messages and pass context messages, etc. to child components
* pass messages, etc. to child components on ContextPasser
* intl strings + context on settings edit form

And a fix about a bug indicated on slack about mailchimp.