### PR TITLE
Fixes - Episode II

### DIFF
--- a/packages/nova-base-components/lib/categories/CategoriesList.jsx
+++ b/packages/nova-base-components/lib/categories/CategoriesList.jsx
@@ -1,7 +1,7 @@
 import React, { PropTypes, Component } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { Button, DropdownButton, MenuItem, Modal } from 'react-bootstrap';
-import { ModalTrigger, ContextPasser } from "meteor/nova:core";
+import { /* ModalTrigger, */ ContextPasser } from "meteor/nova:core";
 import { withRouter } from 'react-router'
 import { LinkContainer } from 'react-router-bootstrap';
 

--- a/packages/nova-base-components/lib/categories/Category.jsx
+++ b/packages/nova-base-components/lib/categories/Category.jsx
@@ -1,7 +1,7 @@
 import React, { PropTypes, Component } from 'react';
 import { Button, DropdownButton, MenuItem } from 'react-bootstrap';
 import classNames from "classnames";
-import { Messages, ModalTrigger } from 'meteor/nova:core';
+//import { Messages, ModalTrigger } from 'meteor/nova:core';
 import { LinkContainer } from 'react-router-bootstrap';
 import { withRouter } from 'react-router'
 

--- a/packages/nova-base-components/lib/posts/PostsEditForm.jsx
+++ b/packages/nova-base-components/lib/posts/PostsEditForm.jsx
@@ -51,7 +51,10 @@ class PostsEditForm extends Component{
             // note: the document prop will be passed from DocumentContainer
             collection: Posts,
             currentUser: this.context.currentUser,
-            methodName: "posts.edit"
+            methodName: "posts.edit",
+            successCallback: (post) => { 
+              this.context.messages.flash(this.context.intl.formatMessage({id: "posts.edit_success"}, {title: post.title}), 'success')
+            }
           }}
         />
         <hr/>

--- a/packages/nova-base-components/lib/posts/PostsNewButton.jsx
+++ b/packages/nova-base-components/lib/posts/PostsNewButton.jsx
@@ -18,6 +18,7 @@ PostsNewButton.displayName = "PostsNewButton";
 
 PostsNewButton.contextTypes = {
   currentUser: React.PropTypes.object,
+  messages: React.PropTypes.object,
   intl: intlShape
 }
 

--- a/packages/nova-base-components/lib/posts/PostsNewForm.jsx
+++ b/packages/nova-base-components/lib/posts/PostsNewForm.jsx
@@ -15,7 +15,7 @@ const PostsNewForm = (props, context) => {
           currentUser={context.currentUser}
           methodName="posts.new"
           successCallback={(post)=>{
-            this.context.messages.flash(context.intl.formatMessage({id: "posts.created_message"}), "success");
+            context.messages.flash(context.intl.formatMessage({id: "posts.created_message"}), "success");
             router.push({pathname: Posts.getPageUrl(post)});
           }}
         />

--- a/packages/nova-base-components/lib/users/UsersEdit.jsx
+++ b/packages/nova-base-components/lib/users/UsersEdit.jsx
@@ -4,7 +4,7 @@ import { Row, Col } from 'react-bootstrap';
 import NovaForm from "meteor/nova:forms";
 //import { Messages } from "meteor/nova:core";
 
-const UsersEdit = ({document, currentUser}) => {
+const UsersEdit = ({document, currentUser}, context) => {
 
   const user = document;
   //const label = `Edit profile for ${Users.getDisplayName(user)}`;
@@ -19,7 +19,7 @@ const UsersEdit = ({document, currentUser}) => {
           document={user} 
           methodName="users.edit"
           successCallback={(user)=>{
-            this.context.messages.flash("User updated.", "success");
+            context.messages.flash("User updated.", "success");
           }}
         />
       </div>

--- a/packages/nova-core/lib/components/ModalTrigger.jsx
+++ b/packages/nova-core/lib/components/ModalTrigger.jsx
@@ -48,7 +48,13 @@ class ModalTrigger extends Component {
         <Modal bsSize={this.props.size} show={this.state.modalIsOpen} onHide={this.closeModal}>
           {this.props.title ? this.renderHeader() : null}
           <Modal.Body>
-            <ContextPasser currentUser={this.context.currentUser} closeCallback={this.closeModal}>
+            <ContextPasser 
+              currentUser={this.context.currentUser}
+              actions={this.context.actions}
+              events={this.context.events}
+              messages={this.context.messages}
+              closeCallback={this.closeModal}
+            >
               {this.props.children}
             </ContextPasser>
           </Modal.Body>
@@ -68,7 +74,10 @@ ModalTrigger.defaultProps = {
 }
 
 ModalTrigger.contextTypes = {
-  currentUser: React.PropTypes.object
+  currentUser: React.PropTypes.object,
+  actions: React.PropTypes.object,
+  events: React.PropTypes.object,
+  messages: React.PropTypes.object
 };
 
 // ModalTrigger.childContextTypes = {

--- a/packages/nova-i18n-en-us/lib/en_US.js
+++ b/packages/nova-i18n-en-us/lib/en_US.js
@@ -4,6 +4,7 @@ Telescope.strings.en = {
 
   "posts.new_post": "New Post",
   "posts.edit": "Edit",
+  "posts.edit_success": "Post “{title}” edited.",
   "posts.delete": "Delete",
   "posts.delete_confirm": "Delete post “{title}”?",
   "posts.delete_success": "Post “{title}” deleted.",


### PR DESCRIPTION
Some stuff I didn't see yesterday night (#1348)

1. Context param for messages.flash on `UsersEdit` https://github.com/TelescopeJS/Telescope/commit/1d047b92e00fcc9e07aa85eaa53299fbe96ebdf5
2. Commenting Messages & ModalTrigger not used anymore https://github.com/TelescopeJS/Telescope/commit/80544da87179e0f3d34c02c69beac97dea450398
3. contextTypes messages on PostsNewButton so the ModalTrigger and PostsNewForm benefit of it! => contextTypes actions, events, messages on ModalTrigger (enable post delete) https://github.com/TelescopeJS/Telescope/commit/cfb720cdcf2dad2495e7c89722a89018db3a8b9a
4. In the row, add a success message on post edit 😌  https://github.com/TelescopeJS/Telescope/commit/6dabd211936a465053f96e9457a28afa65f8318f

So this PR is about context in the most, however we had this discussion on Slack about a bug when autoSubscribe settings is true, here is a view of my fix:
https://gist.github.com/xavcz/7ab1c2a454534fee6889bdc4703852aa

I didn't commit it yet. If you think it's ok, I add it to this PR 👍 