### PR TITLE
Add polyfill for Intl.

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -8,6 +8,7 @@ aldeed:schema-deny@1.0.1
 aldeed:schema-index@1.0.1
 aldeed:simple-schema@1.5.3
 allow-deny@1.0.4
+andylash:intljs@0.1.1
 autoupdate@1.2.9
 babel-compiler@6.6.4
 babel-runtime@0.1.8

--- a/packages/nova-base-components/package.js
+++ b/packages/nova-base-components/package.js
@@ -25,7 +25,8 @@ Package.onUse(function (api) {
     'tmeasday:check-npm-versions@0.3.1',
     'std:accounts-ui@1.2.6',
     'utilities:react-list-container@0.1.10',
-    'kadira:dochead@1.5.0'
+    'kadira:dochead@1.5.0',
+    'andylash:intljs' //polyfill for intl on Safari
   ]);
 
   api.addFiles([


### PR DESCRIPTION
Safari and other older browsers don't support the new JS Intl API. So
react-intl will not work on these browsers and prevents navigation. The
fix is to use the included polyfill.