### PR TITLE
Fix post link when viewing post

### DIFF
--- a/packages/nova-base-components/lib/posts/PostsItem.jsx
+++ b/packages/nova-base-components/lib/posts/PostsItem.jsx
@@ -52,7 +52,7 @@ class PostsItem extends Component {
         <div className="posts-item-content">
           
           <h3 className="posts-item-title">
-            <Link to={`posts/${post._id}/${post.slug}/`} /*to={{name: "posts.single", params: {_id: post._id, slug: post.slug}}}*/ className="posts-item-title-link" target={Posts.getLinkTarget(post)}>
+            <Link to={`/posts/${post._id}/${post.slug}/`} /*to={{name: "posts.single", params: {_id: post._id, slug: post.slug}}}*/ className="posts-item-title-link" target={Posts.getLinkTarget(post)}>
               {post.title}
             </Link>
             {this.renderCategories()}


### PR DESCRIPTION
When trailing forward slash is missing from post link, the link href doubles up when viewing the post. Not sure why there is a post link when viewing the post since you are already viewing the post but regardless it should work.

To reproduce the issue, create new clone of Telescope branch devel and open a post then click on it's title again.