### PR TITLE
🐙 Fix custom package

### DIFF
--- a/packages/my-custom-package/lib/components/CustomPostsItem.jsx
+++ b/packages/my-custom-package/lib/components/CustomPostsItem.jsx
@@ -1,4 +1,5 @@
 import React, { PropTypes, Component } from 'react';
+import moment from 'moment';
 
 class CustomPostsItem extends Telescope.components.PostsItem {
 

--- a/packages/my-custom-package/lib/intl.js
+++ b/packages/my-custom-package/lib/intl.js
@@ -1,7 +1,7 @@
 /*
-  Let's add an international label to the field added in custom_fields
+  Let's add an international label to the field added in custom_fields.js
 */
-Telescope.strings.add({
-  "posts.color": "Color" // collection.field: "Label"
-}, "en"); // define the lang (en, fr, ...)
-
+Telescope.strings.en = {
+  ...Telescope.strings.en, // get all the string translated
+  "posts.color": "Color" // add a new one (collection.field: "Label")
+};

--- a/packages/my-custom-package/lib/intl.js
+++ b/packages/my-custom-package/lib/intl.js
@@ -1,0 +1,7 @@
+/*
+  Let's add an international label to the field added in custom_fields
+*/
+Telescope.strings.add({
+  "posts.color": "Color" // collection.field: "Label"
+}, "en"); // define the lang (en, fr, ...)
+

--- a/packages/my-custom-package/lib/modules.js
+++ b/packages/my-custom-package/lib/modules.js
@@ -5,4 +5,5 @@ Let's import all our files here.
 import "./callbacks.js"
 import "./components.js"
 import "./custom_fields.js"
+import "./intl.js"
 import "./routes.jsx"

--- a/packages/my-custom-package/lib/routes.jsx
+++ b/packages/my-custom-package/lib/routes.jsx
@@ -3,15 +3,6 @@ A new custom route for our custom page.
 Browse to http://localhost:3000/my-custom-route to see it.
 */
 
-import React from 'react';
-import {mount} from 'react-mounter';
-
 import MyCustomPage from './components/MyCustomPage.jsx';
 
-FlowRouter.route('/my-custom-route', {
-  name: 'myCustomRoute',
-  action(params, queryParams) {
-
-    mount(Telescope.components.App, {content: <MyCustomPage />})
-  }
-});
+Telescope.routes.add({name:"custom-page", path:"/my-custom-route", component:MyCustomPage});

--- a/packages/my-custom-package/lib/routes.jsx
+++ b/packages/my-custom-package/lib/routes.jsx
@@ -5,4 +5,4 @@ Browse to http://localhost:3000/my-custom-route to see it.
 
 import MyCustomPage from './components/MyCustomPage.jsx';
 
-Telescope.routes.add({name:"custom-page", path:"/my-custom-route", component:MyCustomPage});
+Telescope.routes.add({name:"myCustomRoute", path:"/my-custom-route", component:MyCustomPage});

--- a/packages/nova-base-components/lib/common/Newsletter.jsx
+++ b/packages/nova-base-components/lib/common/Newsletter.jsx
@@ -60,6 +60,14 @@ class Newsletter extends Component {
     Cookie.save('showBanner', "no");
   }
 
+  renderButton() {
+    return <Telescope.components.NewsletterButton
+              successCallback={() => this.successCallbackSubscription}
+              subscribeText={this.context.intl.formatMessage({id: "newsletter.subscribe"})}
+              user={this.context.currentUser}
+            />
+  }
+
   renderForm() {
     return (
       <Formsy.Form className="newsletter-form" onSubmit={this.subscribeEmail}>
@@ -76,20 +84,12 @@ class Newsletter extends Component {
   }
 
   render() {
-    const currentUser = this.context.currentUser;
 
     return this.state.showBanner
       ? (
         <div className="newsletter">
           <h4 className="newsletter-tagline"><FormattedMessage id="newsletter.subscribe_prompt"/></h4>
-          {this.context.currentUser
-            ? <Telescope.components.NewsletterButton
-                successCallback={() => this.successCallbackSubscription}
-                subscribeText={this.context.intl.formatMessage({id: "newsletter.subscribe"})}
-                user={currentUser}
-              />
-            : this.renderForm()
-          }
+          {this.context.currentUser ? this.renderButton() : this.renderForm()}
           <a onClick={this.dismissBanner} className="newsletter-close"><Telescope.components.Icon name="close"/></a>
         </div>
       ) : null;

--- a/packages/nova-lib/lib/config.js
+++ b/packages/nova-lib/lib/config.js
@@ -61,17 +61,7 @@ Telescope.subscriptions.preload = function (subscription, args) {
 
 // ------------------------------------- Strings -------------------------------- //
 
-Telescope.strings = {
-  transformArrayInObject(arrayOfObj) {
-    let result = {};
-    arrayOfObj.forEach(obj => { result = { ...result, ...obj } });
-    return result;
-  },
-  add(stringOrStringsArray, lang) {
-    const addedStrings = Array.isArray(stringOrStringsArray) ? this.transformArrayInObject(stringOrStringsArray) : stringOrStringsArray;
-    this[lang] = {...this[lang], ...addedStrings};
-  }
-};
+Telescope.strings = {};
 
 // ------------------------------------- Routes -------------------------------- //
 

--- a/packages/nova-lib/lib/config.js
+++ b/packages/nova-lib/lib/config.js
@@ -61,7 +61,17 @@ Telescope.subscriptions.preload = function (subscription, args) {
 
 // ------------------------------------- Strings -------------------------------- //
 
-Telescope.strings = {};
+Telescope.strings = {
+  transformArrayInObject(arrayOfObj) {
+    let result = {};
+    arrayOfObj.forEach(obj => { result = { ...result, ...obj } });
+    return result;
+  },
+  add(stringOrStringsArray, lang) {
+    const addedStrings = Array.isArray(stringOrStringsArray) ? this.transformArrayInObject(stringOrStringsArray) : stringOrStringsArray;
+    this[lang] = {...this[lang], ...addedStrings};
+  }
+};
 
 // ------------------------------------- Routes -------------------------------- //
 


### PR DESCRIPTION
I was so into custom packages and understanding react-router + `Telescope.routes` that when I saw that the custom package had used FlowRouter... I couldn't resist 😂 

🎢  Replacement `FlowRouter.route(...)` by `Telescope.routes.add(...)`. 
⌛  Import `moment` where needed.
✉️  `this.renderButton()` wasn't defined anymore (https://github.com/TelescopeJS/Telescope/blob/master/packages/my-custom-package/lib/components/CustomNewsletter.jsx#L24) after the refactoring on the button -> instead of copy/pasting the code of `Telescope.components.NewsletterButton` and its props + context, I recreated the method `.renderButton`.
