### PR TITLE
use original PostsItem component

### DIFF
--- a/packages/my-custom-package/lib/components/CustomPostsItem.jsx
+++ b/packages/my-custom-package/lib/components/CustomPostsItem.jsx
@@ -5,7 +5,7 @@ import moment from 'moment';
 import { ModalTrigger } from "meteor/nova:core";
 import { Link } from 'react-router';
 
-class CustomPostsItem extends Component {
+class CustomPostsItem extends Telescope.components.PostsItem {
 
   render() {
 


### PR DESCRIPTION
Completing your last commit on `master`, just a fix on `PostsItem` which didn't render anymore because it couldn't access to its methods `renderCategories` et al. 😅 