### PR TITLE
Use defined language (fallbacks to "en")

### DIFF
--- a/packages/nova-base-components/lib/common/App.jsx
+++ b/packages/nova-base-components/lib/common/App.jsx
@@ -5,7 +5,7 @@ import { AppComposer } from "meteor/nova:core";
 class App extends Component {
 
   getLocale() {
-    return Telescope.settings.get("locale", "en");
+    return Telescope.settings.get("locale", Meteor.settings.public.language || "en");
   }
 
   getChildContext() {


### PR DESCRIPTION
Settings defined language is not been used (forced to "en")