### PR TITLE
Decouple components actions from Meteor

### DIFF
--- a/packages/nova-base-components/lib/comments/CommentsItem.jsx
+++ b/packages/nova-base-components/lib/comments/CommentsItem.jsx
@@ -49,7 +49,7 @@ class CommentsItem extends Component{
     const deleteSuccessMessage = this.context.intl.formatMessage({id: "comments.delete_success"}, {body: Telescope.utils.trimWords(comment.body, 20)});
     
     if (window.confirm(deleteConfirmMessage)) {
-      Meteor.call('comments.deleteById', comment._id, (error, result) => {
+      this.context.actions.call('comments.deleteById', comment._id, (error, result) => {
         this.context.messages.flash(deleteSuccessMessage, "success");
         this.context.events.track("comment deleted", {'_id': comment._id});
       });
@@ -122,6 +122,7 @@ CommentsItem.propTypes = {
 }
 
 CommentsItem.contextTypes = {
+  actions: React.PropTypes.object,
   messages: React.PropTypes.object,
   events: React.PropTypes.object,
   intl: intlShape

--- a/packages/nova-base-components/lib/common/NewsletterButton.jsx
+++ b/packages/nova-base-components/lib/common/NewsletterButton.jsx
@@ -14,7 +14,7 @@ class NewsletterButton extends Component {
     const action = Users.getSetting(this.context.currentUser, 'newsletter_subscribeToNewsletter', false) ? 
       'newsletter.removeUser' : 'newsletter.addUser';
 
-    Meteor.call(action, this.context.currentUser, (error, result) => {
+    this.context.actions.call(action, this.context.currentUser, (error, result) => {
       if (error) {
         console.log(error);
         this.context.messages.flash(error.message, "error");
@@ -45,7 +45,8 @@ NewsletterButton.propTypes = {
 
 NewsletterButton.contextTypes = {
   currentUser: React.PropTypes.object,
-  messages: React.PropTypes.object
+  messages: React.PropTypes.object,
+  actions: React.PropTypes.object,
 }
 
 module.exports = NewsletterButton;

--- a/packages/nova-embedly/lib/components/EmbedlyURL.jsx
+++ b/packages/nova-embedly/lib/components/EmbedlyURL.jsx
@@ -18,7 +18,7 @@ class EmbedlyURL extends Component {
     this.setState({loading: true});
 
     // the URL has changed, get a new thumbnail
-    Meteor.call("getEmbedlyData", this.input.getValue(), (error, result) => {
+    this.context.actions.call("getEmbedlyData", this.input.getValue(), (error, result) => {
       
       console.log("querying Embedly…");
       
@@ -79,7 +79,8 @@ EmbedlyURL.propTypes = {
 
 EmbedlyURL.contextTypes = {
   addToAutofilledValues: React.PropTypes.func,
-  throwError: React.PropTypes.func
+  throwError: React.PropTypes.func,
+  actions: React.PropTypes.object,
 }
 
 export default EmbedlyURL;


### PR DESCRIPTION
I saw these 3 components missing the "context refactoring" for Storybook, etc.

Btw, `NovaForms` also depends on explicit `Meteor.call`. As you want it to be used in non-Nova projects, should it use context actions or stay with Meteor.call? I didn't modify it.