### PR TITLE
Different fixes

### DIFF
--- a/packages/nova-base-components/lib/categories/CategoriesNewForm.jsx
+++ b/packages/nova-base-components/lib/categories/CategoriesNewForm.jsx
@@ -1,5 +1,6 @@
 import React, { PropTypes, Component } from 'react';
 //import { Messages } from "meteor/nova:core";
+import Categories from "meteor/nova:categories";
 import NovaForm from "meteor/nova:forms";
 
 const CategoriesNewForm = (props, context) => {

--- a/packages/nova-base-components/lib/common/HeadTags.jsx
+++ b/packages/nova-base-components/lib/common/HeadTags.jsx
@@ -5,15 +5,21 @@ class HeadTags extends Component {
 	render() {
 		DocHead.removeDocHeadAddedTags();
 
-		const url = this.props.url ? this.props.url : Telescope.utils.getSiteUrl();
-		const title = this.props.title ? this.props.title : Telescope.settings.get("title", "Nova");
-		const description = this.props.description ? this.props.description : Telescope.settings.get("tagline");
+		const url = !!this.props.url ? this.props.url : Telescope.utils.getSiteUrl();
+		const title = !!this.props.title ? this.props.title : Telescope.settings.get("title", "Nova");
+		const description = !!this.props.description ? this.props.description : Telescope.settings.get("tagline");
 
-		let image = Telescope.utils.getSiteUrl() + Telescope.settings.get("logoUrl");
-		if (!!this.props && !!this.props.image) {
-			image = this.props.image;
-		} else if (!!Telescope.settings.get("siteImage")) {
-			image = Telescope.settings.get("siteImage");
+		// default image meta: logo url, else site image defined in settings
+		let image = !!Telescope.settings.get("siteImage") ? Telescope.settings.get("siteImage"): Telescope.settings.get("logoUrl");
+		
+		// overwrite default image if one is passed as props 
+		if (!!this.props.image) {
+			image = this.props.image; 
+		}
+
+		// add site url base if the image is stored locally
+		if (image.indexOf('//') === -1) {
+			image = Telescope.utils.getSiteUrl() + image;
 		}
 
 		const metas = [

--- a/packages/nova-base-components/lib/common/Vote.jsx
+++ b/packages/nova-base-components/lib/common/Vote.jsx
@@ -20,11 +20,11 @@ class Vote extends Component {
     if(!user){
       this.context.messages.flash("Please log in first");
     } else if (user.hasUpvoted(post)) {
-      this.context.actions.call('posts.cancelUpvote', post._id, function(){
+      this.context.actions.call('posts.cancelUpvote', post._id, () => {
         this.context.events.track("post upvote cancelled", {'_id': post._id});
       });        
     } else {
-      this.context.actions.call('posts.upvote', post._id, function(){
+      this.context.actions.call('posts.upvote', post._id, () => {
         this.context.events.track("post upvoted", {'_id': post._id});
       });
     }

--- a/packages/nova-base-components/lib/users/UsersAccount.jsx
+++ b/packages/nova-base-components/lib/users/UsersAccount.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { DocumentContainer } from "meteor/utilities:react-list-container";
+import Users from 'meteor/nova:users';
 
 const UsersAccount = (props, context) => {
   const params = props.params.slug ? props.params : {_id: context.currentUser._id};

--- a/packages/nova-base-components/lib/users/UsersSingle.jsx
+++ b/packages/nova-base-components/lib/users/UsersSingle.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { DocumentContainer } from "meteor/utilities:react-list-container";
+import Users from 'meteor/nova:users';
 
 const UsersSingle = (props, context) => {
   return (

--- a/packages/nova-users/lib/server/publications.js
+++ b/packages/nova-users/lib/server/publications.js
@@ -11,7 +11,6 @@ Meteor.publish('users.single', function (terms) {
   var findBySlug = Meteor.users.findOne({"telescope.slug": idOrSlug});
   var user = typeof findById !== 'undefined' ? findById : findBySlug;
   var options = Users.is.admin(this.userId) ? {} : {fields: Users.publishedFields.public};
-  console.log(options);
   return user ? Meteor.users.find({_id: user._id}, options) : [];
 
 });

--- a/packages/nova-users/lib/server/publications.js
+++ b/packages/nova-users/lib/server/publications.js
@@ -1,3 +1,5 @@
+import Users from '../modules.js';
+
 /**
  * @summary Publish a single user
  * @param {String} idOrSlug
@@ -8,8 +10,8 @@ Meteor.publish('users.single', function (terms) {
   var findById = Meteor.users.findOne(idOrSlug);
   var findBySlug = Meteor.users.findOne({"telescope.slug": idOrSlug});
   var user = typeof findById !== 'undefined' ? findById : findBySlug;
-  var options = Users.is.adminById(this.userId) ? {} : {fields: Users.publishedFields.public};
-
+  var options = Users.is.admin(this.userId) ? {} : {fields: Users.publishedFields.public};
+  console.log(options);
   return user ? Meteor.users.find({_id: user._id}, options) : [];
 
 });


### PR DESCRIPTION
Howdy! 👋 

Here are some stuffs I fixed while playing with the app!

1. 8cb454d : `function()` didn't let `this` `context` go through. (💭  this keyword, context, this context, mmmh. there surely a pun to make but I'm not good english speaker enough)

2. d57cfcf : we couldn't create new category anymore, collection imported in `CategoriesNewForm`

3. c67c04f : Clean a little `HeadTags` and fix a bug: 
=> cleaning: by default the image meta is the logo url defined in settings (force 0). It can also be the siteImage defined in settings (force 1). Or last but not least a props passed to the HeadTags component (force 2). 
=> bug fix: if the image specified is a complete url http, ftp or whatever (contains `//`), don't do anything. Else this would mean it's stored locally, add telescope site url.

4. bfcc395 : I found that user profile and edit account was in perpetual loading state -> imported `Users` where it was needed for them, publication & components! (4bf0a15 console.log removal)

Considering this last part about `Users`, in roles: `Users.is.adminById = Users.is.admin`. Is this `adminById` a tweaky remainder of good ol' Legacy? Shall we change it by `.admin` when we encounter it or leave at it is?

Cheers! 🚀 