### PR TITLE
Meta SSR with react-helmet

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "react-bootstrap-datetimepicker": "0.0.22",
     "react-cookie": "^0.4.6",
     "react-dom": "^15.0.0",
+    "react-helmet": "^3.1.0",
     "react-intl": "^2.1.3",
     "react-komposer": "^1.8.0",
     "react-mounter": "^1.2.0",

--- a/packages/nova-base-components/lib/common/HeadTags.jsx
+++ b/packages/nova-base-components/lib/common/HeadTags.jsx
@@ -1,9 +1,8 @@
 import React, { PropTypes, Component } from 'react';
-import { DocHead } from 'meteor/kadira:dochead';
+import Helmet from 'react-helmet';
 
 class HeadTags extends Component {
 	render() {
-		DocHead.removeDocHeadAddedTags();
 
 		const url = !!this.props.url ? this.props.url : Telescope.utils.getSiteUrl();
 		const title = !!this.props.title ? this.props.title : Telescope.settings.get("title", "Nova");
@@ -22,7 +21,7 @@ class HeadTags extends Component {
 			image = Telescope.utils.getSiteUrl() + image;
 		}
 
-		const metas = [
+		const meta = [
 			{ charset: "utf-8" },
 			{ name: "description", content: description },
 			// responsive
@@ -40,16 +39,14 @@ class HeadTags extends Component {
 			{ name: "twitter:description", content: description }
 		];
 
-		const links = [
+		const link = [
 			{ rel: "canonical", href: Telescope.utils.getSiteUrl() },
 			{ rel: "shortcut icon", href: Telescope.settings.get("favicon", "/img/favicon.ico") }
 		];
 
 		return (
 			<div>
-				{ DocHead.setTitle(title) }
-				{ metas.map(meta => DocHead.addMeta(meta)) }
-				{ links.map(link => DocHead.addLink(link)) }
+				<Helmet title={title} meta={meta} link={link} />
 			</div>
 		);
 	}

--- a/packages/nova-base-components/package.js
+++ b/packages/nova-base-components/package.js
@@ -22,7 +22,6 @@ Package.onUse(function (api) {
     'tmeasday:check-npm-versions@0.3.1',
     'std:accounts-ui@1.2.6',
     'utilities:react-list-container@0.1.10',
-    'kadira:dochead@1.5.0'
   ]);
 
   api.mainModule("lib/server.js", "server");

--- a/packages/nova-base-routes/lib/routes.jsx
+++ b/packages/nova-base-routes/lib/routes.jsx
@@ -7,6 +7,7 @@ import { ListContainer, DocumentContainer } from "meteor/utilities:react-list-co
 // import useNamedRoutes from 'use-named-routes';
 import createBrowserHistory from 'history/lib/createBrowserHistory';
 import Events from "meteor/nova:events";
+import Helmet from 'react-helmet';
 
 // // ------------------------------------- Other -------------------------------- //
 
@@ -48,6 +49,11 @@ Meteor.startup(() => {
 
   clientOptions.props = {onUpdate: () => {Events.analyticsRequest(); Messages.clearSeen();}};
 
+  serverOptions.htmlHook = (html) => {
+    const head = Helmet.rewind();
+    return html.replace('<head>', '<head>'+ head.title + head.meta + head.link);    
+  }
+  
   // ReactRouterSSR.Run(AppRoutes, {historyHook: () => history}, {historyHook: () => history});
   ReactRouterSSR.Run(AppRoutes, clientOptions, serverOptions);
 


### PR DESCRIPTION
Got it working! 🎸 

You can view the diff by curling my instance & sidebar :
- Nova with helmet: `curl http://meteor.startupfrance.co` -> has meta in the head
- Nova with dochead: `curl http://nova.sidebar.io` -> no meta in the head

ps: I advice to test with `curl` and not fb debugger because I have a nginx issue with the fb debugger on my instance 😓  I do believe that the scraper would see the meta if nginx is well configured (not my case).