### PR TITLE
don't do modification on a var if undefined => fixes #1375 error

### DIFF
--- a/packages/nova-base-components/lib/common/HeadTags.jsx
+++ b/packages/nova-base-components/lib/common/HeadTags.jsx
@@ -17,7 +17,7 @@ class HeadTags extends Component {
 		}
 
 		// add site url base if the image is stored locally
-		if (image.indexOf('//') === -1) {
+		if (!!image && image.indexOf('//') === -1) {
 			image = Telescope.utils.getSiteUrl() + image;
 		}
 


### PR DESCRIPTION
Error on startup was triggered because the app was started without `--settings ...` flag. However it has unveiled, that if someone remove or doesn't define `logoUrl` field from the settings file, Nova can't boot.

*💭  reminder for myself: don't do modification on a var if undefined*