### PR TITLE
remove double inclusion of base styles

### DIFF
--- a/packages/nova-base-styles/package.js
+++ b/packages/nova-base-styles/package.js
@@ -19,23 +19,6 @@ Package.onUse(function (api) {
 
   api.addFiles([
     'lib/stylesheets/bootstrap.css',
-
-    // 'lib/stylesheets/solid.1.4.4.css',
-    'lib/stylesheets/_breakpoints.scss',
-    'lib/stylesheets/_colors.scss',
-    'lib/stylesheets/_variables.scss',
-    'lib/stylesheets/_global.scss',
-    'lib/stylesheets/_accounts.scss',
-    'lib/stylesheets/_categories.scss',
-    'lib/stylesheets/_cheatsheet.scss',
-    'lib/stylesheets/_comments.scss',
-    'lib/stylesheets/_header.scss',
-    'lib/stylesheets/_forms.scss',
-    'lib/stylesheets/_other.scss',
-    'lib/stylesheets/_posts.scss',
-    'lib/stylesheets/_newsletter.scss',
-    'lib/stylesheets/_spinner.scss',
-    'lib/stylesheets/_users.scss',
     'lib/stylesheets/main.scss'
   ], ['client']);
 


### PR DESCRIPTION
The base styles were included twice, first in `package.js` then imported in `main.scss`
This patch gets rid of the first inclusion.