### PR TITLE
fixed types comparison in Posts.isApproved helper

### DIFF
--- a/packages/nova-posts/lib/helpers.js
+++ b/packages/nova-posts/lib/helpers.js
@@ -82,7 +82,7 @@ Posts.getDefaultStatus = function (user) {
  * @param {Object} post
  */
 Posts.isApproved = function (post) {
-  return post.status === Posts.config.STATUS_APPROVED;
+  return parseInt(post.status) === Posts.config.STATUS_APPROVED;
 };
 Posts.helpers({isApproved: function () {return Posts.isApproved(this);}});
 
@@ -186,15 +186,15 @@ Users.can.viewPost = function (user, post) {
 
       case Posts.config.STATUS_APPROVED:
         return Users.can.view(user);
-      
+
       case Posts.config.STATUS_REJECTED:
       case Posts.config.STATUS_SPAM:
-      case Posts.config.STATUS_PENDING: 
+      case Posts.config.STATUS_PENDING:
         return Users.can.view(user) && Users.is.owner(user, post);
-      
+
       case Posts.config.STATUS_DELETED:
         return false;
-    
+
     }
   }
 }


### PR DESCRIPTION
`Posts.isApproved` helper return 'false' when admin user is adding new post with the Status = "approved" - the `post.status` is a `String` compared with `Integer` value of `Posts.config.STATUS_APPROVED`.
As a result, the `postedAt` value is not stored in the Posts collection, which leads to ugly error whenever `<FormattedRelative value={post.postedAt}/>` is used, i.e. in the `PostsItem`.

<img width="402" src="https://cloud.githubusercontent.com/assets/2128357/16723436/2d8b00c0-474d-11e6-8915-a1cbab75d04b.png">

<img width="729" src="https://cloud.githubusercontent.com/assets/2128357/16723425/228eab04-474d-11e6-87d1-7311055b3a44.png">

I was able to fix this simply by parsing `post.status` with `parseInt()`.
