### PR TITLE
NovaForm: custom control has access to document as a props

### DIFF
--- a/packages/nova-base-components/lib/common/Newsletter.jsx
+++ b/packages/nova-base-components/lib/common/Newsletter.jsx
@@ -62,7 +62,7 @@ class Newsletter extends Component {
 
   renderButton() {
     return <Telescope.components.NewsletterButton
-              successCallback={() => this.successCallbackSubscription}
+              successCallback={() => this.successCallbackSubscription()}
               subscribeText={this.context.intl.formatMessage({id: "newsletter.subscribe"})}
               user={this.context.currentUser}
             />

--- a/packages/nova-base-components/lib/common/NewsletterButton.jsx
+++ b/packages/nova-base-components/lib/common/NewsletterButton.jsx
@@ -11,10 +11,10 @@ class NewsletterButton extends Component {
   }
   
   subscriptionAction() {
-    const action = Users.getSetting(this.context.currentUser, 'newsletter_subscribeToNewsletter', false) ? 
+    const action = Users.getSetting(this.props.user, 'newsletter_subscribeToNewsletter', false) ? 
       'newsletter.removeUser' : 'newsletter.addUser';
 
-    this.context.actions.call(action, this.context.currentUser, (error, result) => {
+    this.context.actions.call(action, this.props.user, (error, result) => {
       if (error) {
         console.log(error);
         this.context.messages.flash(error.message, "error");
@@ -25,7 +25,7 @@ class NewsletterButton extends Component {
   }
 
   render() {
-    const isSubscribed = Users.getSetting(this.context.currentUser, 'newsletter_subscribeToNewsletter', false);
+    const isSubscribed = Users.getSetting(this.props.user, 'newsletter_subscribeToNewsletter', false);
 
     return (
       <Button
@@ -40,7 +40,8 @@ class NewsletterButton extends Component {
 }
 
 NewsletterButton.propTypes = {
-  successCallback: React.PropTypes.func.isRequired
+  successCallback: React.PropTypes.func.isRequired,
+  user: React.PropTypes.object.isRequired,
 };
 
 NewsletterButton.contextTypes = {

--- a/packages/nova-forms/lib/NovaForm.jsx
+++ b/packages/nova-forms/lib/NovaForm.jsx
@@ -116,6 +116,11 @@ class NovaForm extends Component{
         field.group = fieldSchema.group;
       }
 
+      // add document if the control is a React component (cannot access it through the context)
+      if (typeof fieldSchema.control === "function") {
+        field.document = this.getDocument();
+      }
+
       return field;
 
     });

--- a/packages/nova-newsletter/lib/components/NewsletterSubscribe.jsx
+++ b/packages/nova-newsletter/lib/components/NewsletterSubscribe.jsx
@@ -1,16 +1,19 @@
 import React, { PropTypes, Component } from 'react';
-import { Messages } from 'meteor/nova:core';
 
-const NewsletterSubscribe = ({props}) => {
+const NewsletterSubscribe = (props, context) => {
   return (
     <div className="form-group row">
       <label className="control-label col-sm-3">Newsletter</label>
       <div className="col-sm-9">
-        <Telescope.components.NewsletterButton successCallback={() => Messages.flash("Newsletter subscription updated", "success")}/>
+        <Telescope.components.NewsletterButton user={props.document} successCallback={() => context.messages.flash("Newsletter subscription updated", "success")}/>
       </div>
     </div>
   )
 }
+
+NewsletterSubscribe.contextTypes = {
+  messages: React.PropTypes.object,
+};
 
 module.exports = NewsletterSubscribe;
 export default NewsletterSubscribe;


### PR DESCRIPTION
Hey!

It all started by fixing a bug when editing another user as an admin, if you were to click on the user's newsletter setting, it would un/subscribe yourself.

I needed my `NewsletterSubscribe` to have access to the user document. By passing `getDocument` function in the context, I got errors (`this.props.document is undefined`). 

So I have added a new piece of logic when looping through a fieldSchema : if it's a function (React Component), give it a prop `document`. https://github.com/TelescopeJS/Telescope/commit/91cc0e3f1bdc76fa0cf6fe409cee83377d95f4d5

What do you think of that? I believe it can help to create more flexible/what-ever-you-need components in NovaForms.

(so in this PR, I added this logic and fixed the behavior of the newsletter button)