### PR TITLE
Refactored subscribe-to-posts

### DIFF
--- a/packages/_nova-subscribe-to-posts/lib/components/SubscribeButton.jsx
+++ b/packages/_nova-subscribe-to-posts/lib/components/SubscribeButton.jsx
@@ -1,0 +1,74 @@
+import React, { PropTypes, Component } from 'react';
+
+class SubscribeButton extends Component {
+
+  constructor(props, context) {
+    super(props, context);
+
+    this.onSubscribe = this.onSubscribe.bind(this);
+    this.isSubscribed = this.isSubscribed.bind(this);
+  }
+
+  onSubscribe() {
+    const post = this.props.post;
+    const user = this.context.currentUser;
+
+    let callAction = 'subscribePost';
+
+    let isSubscribed = this.isSubscribed(post, user);
+    if( isSubscribed ) {
+      callAction = "unsubscribePost";
+    }
+
+    this.context.actions.call(callAction, post._id, (error, result) => {
+      if (result)
+        this.context.events.track(callAction, {'_id': post._id});
+    })
+  }
+
+  isSubscribed(post, user) {
+    if (!post || !user)
+      return false;
+    return post.subscribers && post.subscribers.indexOf(user._id) != -1;
+  }
+
+  render() {
+    const post = this.props.post;
+    const user = this.context.currentUser;
+
+    // can't subscribe to own post (also validated on server side)
+    if(user && post.author === user.username) {
+      return null
+    }
+
+    let btnStyle = "default";
+
+    let isSubscribed = this.isSubscribed(post, user);
+    if( isSubscribed ) {
+      btnStyle = "info";
+    }
+
+    return (
+      <button type="button" title="Observe"
+        className={`btn btn-${btnStyle} btn-sm pull-right`}
+        style={{padding: '.5rem', lineHeight: 1, borderRadius: '50%', marginLeft: '.5rem'}}
+        onClick={this.onSubscribe} >
+        <i className="fa fa-eye"></i>
+      </button>
+    )
+  }
+
+}
+
+SubscribeButton.propTypes = {
+  post: React.PropTypes.object.isRequired
+}
+
+SubscribeButton.contextTypes = {
+  currentUser: React.PropTypes.object,
+  actions: React.PropTypes.object,
+  events: React.PropTypes.object
+};
+
+module.exports = SubscribeButton;
+export default SubscribeButton;

--- a/packages/_nova-subscribe-to-posts/lib/custom_fields.js
+++ b/packages/_nova-subscribe-to-posts/lib/custom_fields.js
@@ -26,7 +26,6 @@ Posts.addField(
     fieldName: 'subscribers',
     fieldSchema: {
       type: [String],
-      control: "checkboxgroup",
       optional: true,
       insertableIf: canSubscribe,
       autoform: {

--- a/packages/_nova-subscribe-to-posts/lib/custom_fields.js
+++ b/packages/_nova-subscribe-to-posts/lib/custom_fields.js
@@ -1,0 +1,67 @@
+import PublicationUtils from 'meteor/utilities:smart-publications'
+import Posts from "meteor/nova:posts"
+import Users from "meteor/nova:users"
+
+// check if user can subscribe to post
+const canSubscribe = user => Users.canDo(user, "posts.new");
+
+Users.addField({
+  fieldName: 'telescope.subscribedItems',
+  fieldSchema: {
+    type: Object,
+    optional: true,
+    blackbox: true,
+    autoform: {
+      omit: true
+    }
+  }
+});
+
+PublicationUtils.addToFields(
+  Users.publishedFields.list, ["telescope.subscribedItems"]
+)
+
+Posts.addField(
+  {
+    fieldName: 'subscribers',
+    fieldSchema: {
+      type: [String],
+      control: "checkboxgroup",
+      optional: true,
+      insertableIf: canSubscribe,
+      autoform: {
+        // omit: true
+        noselect: true,
+        type: "bootstrap-category",
+        order: 50,
+        options: function () {
+          var subscribers = [{
+            value: "123",
+            label: "razdwatrzy"
+          }];
+          return subscribers;
+        }
+      },
+      publish: true,
+      join: {
+        joinAs: "subscribersArray",
+        collection: () => Users
+      }
+    }
+  }
+);
+
+Posts.addField({
+  fieldName: 'subscriberCount',
+  fieldSchema: {
+    type: Number,
+    optional: true,
+    autoform: {
+      omit: true
+    }
+  }
+});
+
+PublicationUtils.addToFields(
+  Posts.publishedFields.list, ["subscribers", "subscriberCount"]
+)

--- a/packages/_nova-subscribe-to-posts/lib/custom_fields.js
+++ b/packages/_nova-subscribe-to-posts/lib/custom_fields.js
@@ -30,17 +30,7 @@ Posts.addField(
       optional: true,
       insertableIf: canSubscribe,
       autoform: {
-        // omit: true
-        noselect: true,
-        type: "bootstrap-category",
-        order: 50,
-        options: function () {
-          var subscribers = [{
-            value: "123",
-            label: "razdwatrzy"
-          }];
-          return subscribers;
-        }
+        omit: true
       },
       publish: true,
       join: {

--- a/packages/_nova-subscribe-to-posts/lib/custom_fields.js
+++ b/packages/_nova-subscribe-to-posts/lib/custom_fields.js
@@ -2,9 +2,6 @@ import PublicationUtils from 'meteor/utilities:smart-publications'
 import Posts from "meteor/nova:posts"
 import Users from "meteor/nova:users"
 
-// check if user can subscribe to post
-const canSubscribe = user => Users.canDo(user, "posts.new");
-
 Users.addField({
   fieldName: 'telescope.subscribedItems',
   fieldSchema: {
@@ -17,17 +14,12 @@ Users.addField({
   }
 });
 
-PublicationUtils.addToFields(
-  Users.publishedFields.list, ["telescope.subscribedItems"]
-)
-
-Posts.addField(
+Posts.addField([
   {
     fieldName: 'subscribers',
     fieldSchema: {
       type: [String],
       optional: true,
-      insertableIf: canSubscribe,
       autoform: {
         omit: true
       },
@@ -37,20 +29,18 @@ Posts.addField(
         collection: () => Users
       }
     }
-  }
-);
-
-Posts.addField({
-  fieldName: 'subscriberCount',
-  fieldSchema: {
-    type: Number,
-    optional: true,
-    autoform: {
-      omit: true
+  },
+  {
+    fieldName: 'subscriberCount',
+    fieldSchema: {
+      type: Number,
+      optional: true,
+      autoform: {
+        omit: true
+      }
     }
   }
-});
+]);
 
-PublicationUtils.addToFields(
-  Posts.publishedFields.list, ["subscribers", "subscriberCount"]
-)
+PublicationUtils.addToFields(Users.publishedFields.list, ["telescope.subscribedItems"]);
+PublicationUtils.addToFields(Posts.publishedFields.list, ["subscribers", "subscriberCount"]);

--- a/packages/_nova-subscribe-to-posts/lib/export.js
+++ b/packages/_nova-subscribe-to-posts/lib/export.js
@@ -1,0 +1,8 @@
+import {subscribeItem, unsubscribeItem} from './methods.js';
+import SubscribeButton from './components/SubscribeButton.jsx';
+
+export {
+  subscribeItem,
+  unsubscribeItem,
+  SubscribeButton
+}

--- a/packages/_nova-subscribe-to-posts/lib/methods.js
+++ b/packages/_nova-subscribe-to-posts/lib/methods.js
@@ -23,7 +23,7 @@ var removeSubscribedItem = function (userId, itemId, collectionName) {
   });
 };
 
-subscribeItem = function (collection, itemId, user) {
+export var subscribeItem = function (collection, itemId, user) {
 
   var item = collection.findOne(itemId),
       collectionName = collection._name.slice(0,1).toUpperCase() + collection._name.slice(1);
@@ -53,9 +53,9 @@ subscribeItem = function (collection, itemId, user) {
   return true;
 };
 
-unsubscribeItem = function (collection, itemId, user) {
-  var user = Meteor.user(),
-      item = collection.findOne(itemId),
+export var unsubscribeItem = function (collection, itemId, user) {
+
+  var item = collection.findOne(itemId),
       collectionName = collection._name.slice(0,1).toUpperCase()+collection._name.slice(1);
 
   if (!user || !item  || !hasSubscribedItem(item, user))

--- a/packages/_nova-subscribe-to-posts/lib/methods.js
+++ b/packages/_nova-subscribe-to-posts/lib/methods.js
@@ -1,0 +1,86 @@
+import Posts from "meteor/nova:posts";
+import Users from 'meteor/nova:users';
+
+var hasSubscribedItem = function (item, user) {
+  return item.subscribers && item.subscribers.indexOf(user._id) != -1;
+};
+
+var addSubscribedItem = function (userId, item, collectionName) {
+  var field = 'telescope.subscribedItems.' + collectionName;
+  var add = {};
+  add[field] = item;
+  Meteor.users.update({_id: userId}, {
+    $addToSet: add
+  });
+};
+
+var removeSubscribedItem = function (userId, itemId, collectionName) {
+  var field = 'telescope.subscribedItems.' + collectionName;
+  var remove = {};
+  remove[field] = {itemId: itemId};
+  Meteor.users.update({_id: userId}, {
+    $pull: remove
+  });
+};
+
+subscribeItem = function (collection, itemId, user) {
+
+  var item = collection.findOne(itemId),
+      collectionName = collection._name.slice(0,1).toUpperCase() + collection._name.slice(1);
+
+  if (!user || !item || hasSubscribedItem(item, user))
+    return false;
+
+  // author can't subscribe item
+  if (item.userId && item.userId === user._id)
+    return false
+
+  // Subscribe
+  var result = collection.update({_id: itemId, subscribers: { $ne: user._id }}, {
+    $addToSet: {subscribers: user._id},
+    $inc: {subscriberCount: 1}
+  });
+
+  if (result > 0) {
+    // Add item to list of subscribed items
+    var obj = {
+      itemId: item._id,
+      subscribedAt: new Date()
+    };
+    addSubscribedItem(user._id, obj, collectionName);
+  }
+
+  return true;
+};
+
+unsubscribeItem = function (collection, itemId, user) {
+  var user = Meteor.user(),
+      item = collection.findOne(itemId),
+      collectionName = collection._name.slice(0,1).toUpperCase()+collection._name.slice(1);
+
+  if (!user || !item  || !hasSubscribedItem(item, user))
+    return false;
+
+  // Unsubscribe
+  var result = collection.update({_id: itemId, subscribers: user._id }, {
+    $pull: {subscribers: user._id},
+    $inc: {subscriberCount: -1}
+  });
+
+  if (result > 0) {
+    // Remove item from list of subscribed items
+    removeSubscribedItem(user._id, itemId, collectionName);
+  }
+  return true;
+};
+
+Meteor.methods({
+  subscribePost: function(postId) {
+    check(postId, String);
+    return subscribeItem.call(this, Posts, postId, Meteor.user());
+  },
+  unsubscribePost: function(postId) {
+    check(postId, String);
+    return unsubscribeItem.call(this, Posts, postId, Meteor.user());
+  }
+});

--- a/packages/_nova-subscribe-to-posts/package.js
+++ b/packages/_nova-subscribe-to-posts/package.js
@@ -14,8 +14,17 @@ Package.onUse(function (api) {
 
   // automatic (let the package specify where it's needed)
 
-  api.use(['nova:core@0.26.5-nova']);
+  api.use([
+    'nova:core@0.26.5-nova',
+    'nova:posts@0.26.5-nova',
+    'nova:users@0.26.5-nova'
+  ]);
 
+  // api.use([
+  //   'nova:notifications@0.26.5-nova',
+  //   'nova:email@0.26.5-nova'
+  // ], ['client', 'server'], {weak: true});
+  //
   // ---------------------------------- 2. Files to include ----------------------------------
 
   // i18n config (must come first)
@@ -59,5 +68,7 @@ Package.onUse(function (api) {
   //   'subscribeItem',
   //   'unsubscribeItem'
   // ]);
+
+  api.mainModule("lib/export.js", ["client", "server"]);
 
 });

--- a/packages/_nova-subscribe-to-posts/package.js
+++ b/packages/_nova-subscribe-to-posts/package.js
@@ -20,24 +20,26 @@ Package.onUse(function (api) {
 
   // i18n config (must come first)
 
-  api.addFiles([
-    'package-tap.i18n'
-  ], ['client', 'server']);
+  // api.addFiles([
+  //   'package-tap.i18n'
+  // ], ['client', 'server']);
 
   // both
 
   api.addFiles([
-    'lib/subscribe-to-posts.js',
+    // 'lib/subscribe-to-posts.js',',
+    'lib/custom_fields.js',
+    'lib/methods.js'
   ], ['client', 'server']);
 
   // client
 
-  api.addFiles([
-    'lib/client/templates/post_subscribe.html',
-    'lib/client/templates/post_subscribe.js',
-    'lib/client/templates/user_subscribed_posts.html',
-    'lib/client/templates/user_subscribed_posts.js'
-  ], ['client']);
+  // api.addFiles([
+  //   'lib/client/templates/post_subscribe.html',
+  //   'lib/client/templates/post_subscribe.js',
+  //   'lib/client/templates/user_subscribed_posts.html',
+  //   'lib/client/templates/user_subscribed_posts.js'
+  // ], ['client']);
 
   // server
 
@@ -47,15 +49,15 @@ Package.onUse(function (api) {
 
   // i18n languages (must come last)
 
-  var languages = ["ar", "bg", "cs", "da", "de", "el", "en", "es", "et", "fr", "hu", "id", "it", "ja", "kk", "ko", "nl", "pl", "pt-BR", "ro", "ru", "sl", "sv", "th", "tr", "vi", "zh-CN"];
-  var languagesPaths = languages.map(function (language) {
-    return "i18n/"+language+".i18n.json";
-  });
-  api.addFiles(languagesPaths, ["client", "server"]);
-
-  api.export([
-    'subscribeItem',
-    'unsubscribeItem'
-  ]);
+  // var languages = ["ar", "bg", "cs", "da", "de", "el", "en", "es", "et", "fr", "hu", "id", "it", "ja", "kk", "ko", "nl", "pl", "pt-BR", "ro", "ru", "sl", "sv", "th", "tr", "vi", "zh-CN"];
+  // var languagesPaths = languages.map(function (language) {
+  //   return "i18n/"+language+".i18n.json";
+  // });
+  // api.addFiles(languagesPaths, ["client", "server"]);
+  //
+  // api.export([
+  //   'subscribeItem',
+  //   'unsubscribeItem'
+  // ]);
 
 });

--- a/packages/my-custom-package/lib/components/CustomPostsItem.jsx
+++ b/packages/my-custom-package/lib/components/CustomPostsItem.jsx
@@ -1,6 +1,6 @@
 import React, { PropTypes, Component } from 'react';
 import { FormattedMessage, FormattedRelative } from 'react-intl';
-import { Button } from 'react-bootstrap';
+import { Button, Tooltip } from 'react-bootstrap';
 import moment from 'moment';
 import { ModalTrigger } from "meteor/nova:core";
 import { Link } from 'react-router';
@@ -9,11 +9,64 @@ import Categories from "meteor/nova:categories";
 
 class CustomPostsItem extends Telescope.components.PostsItem {
 
+  constructor(props, context) {
+    super(props, context);
+
+    this.renderSubscribeButton = this.renderSubscribeButton.bind(this);
+    this.onSubscribe = this.onSubscribe.bind(this);
+    this.isSubscribed = this.isSubscribed.bind(this);
+  }
+
+  isSubscribed(post, user) {
+    if (!post || !user)
+      return false;
+    return post.subscribers && post.subscribers.indexOf(user._id) != -1;
+  }
+
+  renderSubscribeButton() {
+    const post = this.props.post;
+    const user = this.context.currentUser;
+
+    let btnStyle = "default";
+
+    let isSubscribed = this.isSubscribed(post, user);
+    if( isSubscribed ) {
+      btnStyle = "info";
+    }
+
+    return (
+      <button type="button" title="Observe"
+        className={`btn btn-${btnStyle} btn-sm pull-right`}
+        style={{padding: '.5rem', lineHeight: 1, borderRadius: '50%', marginLeft: '.5rem'}}
+        onClick={this.onSubscribe} >
+        <i className="fa fa-eye"></i>
+      </button>
+    )
+  }
+
+  onSubscribe() {
+    const post = this.props.post;
+    const user = this.context.currentUser;
+
+    let callAction = 'subscribePost';
+
+    let isSubscribed = this.isSubscribed(post, user);
+    if( isSubscribed ) {
+      callAction = "unsubscribePost";
+    }
+
+    this.context.actions.call(callAction, post._id, (error, result) => {
+      if (result)
+        this.context.events.track(callAction, {'_id': post._id});
+    })
+  }
+
   render() {
 
     const post = this.props.post;
+    const user = this.context.currentUser;
 
-    let postClass = "posts-item"; 
+    let postClass = "posts-item";
     if (post.sticky) postClass += " posts-sticky";
 
     // ⭐ custom code starts here ⭐
@@ -24,22 +77,22 @@ class CustomPostsItem extends Telescope.components.PostsItem {
 
     return (
       <div className={postClass}>
-        
+
         <div className="posts-item-vote">
           <Telescope.components.Vote post={post} currentUser={this.context.currentUser}/>
         </div>
-        
+
         {post.thumbnailUrl ? <Telescope.components.PostsThumbnail post={post}/> : null}
 
         <div className="posts-item-content">
-          
+
           <h3 className="posts-item-title">
             <Link to={Posts.getLink(post)} className="posts-item-title-link" target={Posts.getLinkTarget(post)}>
               {post.title}
             </Link>
             {this.renderCategories()}
           </h3>
-          
+
           <div className="posts-item-meta">
             {post.user? <div className="posts-item-user"><Telescope.components.UsersAvatar user={post.user} size="small"/><Telescope.components.UsersName user={post.user}/></div> : null}
             <div className="posts-item-date"><FormattedRelative value={post.postedAt}/></div>
@@ -55,19 +108,22 @@ class CustomPostsItem extends Telescope.components.PostsItem {
         </div>
 
         {this.renderCommenters()}
-        
-      
+
+        {(user && post.author !== user.username) ? this.renderSubscribeButton() : null}
+
       </div>
     )
   }
 };
-  
+
 CustomPostsItem.propTypes = {
   post: React.PropTypes.object.isRequired
 }
 
 CustomPostsItem.contextTypes = {
-  currentUser: React.PropTypes.object
+  currentUser: React.PropTypes.object,
+  actions: React.PropTypes.object,
+  events: React.PropTypes.object
 };
 
 export default CustomPostsItem;

--- a/packages/my-custom-package/lib/components/CustomPostsItem.jsx
+++ b/packages/my-custom-package/lib/components/CustomPostsItem.jsx
@@ -1,6 +1,6 @@
 import React, { PropTypes, Component } from 'react';
 import { FormattedMessage, FormattedRelative } from 'react-intl';
-import { Button, Tooltip } from 'react-bootstrap';
+import { Button } from 'react-bootstrap';
 import moment from 'moment';
 import { ModalTrigger } from "meteor/nova:core";
 import { Link } from 'react-router';
@@ -9,64 +9,11 @@ import Categories from "meteor/nova:categories";
 
 class CustomPostsItem extends Telescope.components.PostsItem {
 
-  constructor(props, context) {
-    super(props, context);
-
-    this.renderSubscribeButton = this.renderSubscribeButton.bind(this);
-    this.onSubscribe = this.onSubscribe.bind(this);
-    this.isSubscribed = this.isSubscribed.bind(this);
-  }
-
-  isSubscribed(post, user) {
-    if (!post || !user)
-      return false;
-    return post.subscribers && post.subscribers.indexOf(user._id) != -1;
-  }
-
-  renderSubscribeButton() {
-    const post = this.props.post;
-    const user = this.context.currentUser;
-
-    let btnStyle = "default";
-
-    let isSubscribed = this.isSubscribed(post, user);
-    if( isSubscribed ) {
-      btnStyle = "info";
-    }
-
-    return (
-      <button type="button" title="Observe"
-        className={`btn btn-${btnStyle} btn-sm pull-right`}
-        style={{padding: '.5rem', lineHeight: 1, borderRadius: '50%', marginLeft: '.5rem'}}
-        onClick={this.onSubscribe} >
-        <i className="fa fa-eye"></i>
-      </button>
-    )
-  }
-
-  onSubscribe() {
-    const post = this.props.post;
-    const user = this.context.currentUser;
-
-    let callAction = 'subscribePost';
-
-    let isSubscribed = this.isSubscribed(post, user);
-    if( isSubscribed ) {
-      callAction = "unsubscribePost";
-    }
-
-    this.context.actions.call(callAction, post._id, (error, result) => {
-      if (result)
-        this.context.events.track(callAction, {'_id': post._id});
-    })
-  }
-
   render() {
 
     const post = this.props.post;
-    const user = this.context.currentUser;
 
-    let postClass = "posts-item";
+    let postClass = "posts-item"; 
     if (post.sticky) postClass += " posts-sticky";
 
     // ⭐ custom code starts here ⭐
@@ -77,22 +24,22 @@ class CustomPostsItem extends Telescope.components.PostsItem {
 
     return (
       <div className={postClass}>
-
+        
         <div className="posts-item-vote">
           <Telescope.components.Vote post={post} currentUser={this.context.currentUser}/>
         </div>
-
+        
         {post.thumbnailUrl ? <Telescope.components.PostsThumbnail post={post}/> : null}
 
         <div className="posts-item-content">
-
+          
           <h3 className="posts-item-title">
             <Link to={Posts.getLink(post)} className="posts-item-title-link" target={Posts.getLinkTarget(post)}>
               {post.title}
             </Link>
             {this.renderCategories()}
           </h3>
-
+          
           <div className="posts-item-meta">
             {post.user? <div className="posts-item-user"><Telescope.components.UsersAvatar user={post.user} size="small"/><Telescope.components.UsersName user={post.user}/></div> : null}
             <div className="posts-item-date"><FormattedRelative value={post.postedAt}/></div>
@@ -108,22 +55,19 @@ class CustomPostsItem extends Telescope.components.PostsItem {
         </div>
 
         {this.renderCommenters()}
-
-        {(user && post.author !== user.username) ? this.renderSubscribeButton() : null}
-
+        
+      
       </div>
     )
   }
 };
-
+  
 CustomPostsItem.propTypes = {
   post: React.PropTypes.object.isRequired
 }
 
 CustomPostsItem.contextTypes = {
-  currentUser: React.PropTypes.object,
-  actions: React.PropTypes.object,
-  events: React.PropTypes.object
+  currentUser: React.PropTypes.object
 };
 
 export default CustomPostsItem;


### PR DESCRIPTION
Here is the basic functionality, with one UI component available by import.

```
import { SubscribeButton } from "meteor/subscribe-to-posts";
...
<SubscribeButton post={post} />
```

Like in original code, the `subscribeItem` and `unsubscribeItem` functions are also exported from the package.

Notifications are being send by callback function CommentsNewNotifications from nova-comments/lib/callbacks.js.

ToDo:
- UI component for `user_subscribed_posts` template
- Moving notification from nova-comments/lib/callbacks.js to subscribe-to-posts.
- Cleanup old code
