### PR TITLE
Proposal for a CanDo Higher-Order Component

### DIFF
--- a/packages/nova-base-components/lib/components.js
+++ b/packages/nova-base-components/lib/components.js
@@ -60,6 +60,7 @@ Telescope.registerComponent("CategoriesNewForm",    require('./categories/Catego
 
 // permissions
 
+Telescope.registerComponent("CanDo",                require('./permissions/CanDo.jsx'));
 Telescope.registerComponent("CanCreatePost",        require('./permissions/CanCreatePost.jsx'));
 Telescope.registerComponent("CanEditPost",          require('./permissions/CanEditPost.jsx'));
 Telescope.registerComponent("CanView",              require('./permissions/CanView.jsx'));

--- a/packages/nova-base-components/lib/permissions/CanDo.jsx
+++ b/packages/nova-base-components/lib/permissions/CanDo.jsx
@@ -1,0 +1,59 @@
+import React, { PropTypes } from 'react';
+import { FormattedMessage } from 'react-intl';
+import Users from 'meteor/nova:users';
+
+const CanDo = (props, context) => {
+  // no user login, display the login form
+  if (!context.currentUser && props.displayNoPermissionMessage) {
+    return (
+      <div className="log-in-message">
+        <h3><FormattedMessage id="users.please_log_in"/></h3>
+        <Telescope.components.UsersAccountForm />
+      </div>
+    );
+  }
+
+  // default permission, is the user allowed to perform this action?
+  let permission = Users.canDo(context.currentUser, props.action);
+
+  // the permission is about viewing a document, check if the user is allowed
+  if (props.document && props.action.indexOf('view') > -1) {
+    // use the permission shortcut canView on the current user and requested document
+    permission = Users.canView(context.currentUser, props.document);
+  }
+
+  // the permission is about editing a document, check if the user is allowed
+  if (props.document && props.action.indexOf('edit') > -1) {
+    // use the permission shortcut canEdit on the current user and requested document
+    permission = Users.canEdit(context.currentUser, props.document);
+  }
+
+  // the user can perform the intented action in the component: display the component, 
+  // else: display a not allowed message
+  if (permission) {
+    return props.children;
+  } else {
+    return props.displayNoPermissionMessage ? <p><FormattedMessage id={props.noPermissionMessage}/></p> : null;
+  }
+};
+
+CanDo.contextTypes = {
+  currentUser: React.PropTypes.object
+};
+
+CanDo.propTypes = {
+  action: React.PropTypes.string.isRequired,
+  document: React.PropTypes.object,
+  noPermissionMessage: React.PropTypes.string,
+  displayNoPermissionMessage: React.PropTypes.bool,
+};
+
+CanDo.defaultProps = {
+  noPermissionMessage: 'app.noPermission',
+  displayNoPermissionMessage: false,
+};
+
+CanDo.displayName = "CanDo";
+
+module.exports = CanDo;
+export default CanDo;

--- a/packages/nova-base-components/lib/posts/PostsItem.jsx
+++ b/packages/nova-base-components/lib/posts/PostsItem.jsx
@@ -18,16 +18,16 @@ class PostsItem extends Component {
   }
 
   renderActions() {
-
-    const component = (
-      <ModalTrigger title="Edit Post" component={<a className="posts-action-edit"><FormattedMessage id="posts.edit"/></a>}>
-        <Telescope.components.PostsEditForm post={this.props.post}/>
-      </ModalTrigger>
-    );
-
     return (
       <div className="post-actions">
-        {Users.canEdit(this.context.currentUser, this.props.post) ? component : ""}
+        <Telescope.components.CanDo
+          action="posts.edit.all"
+          document={this.props.post}
+        >
+          <ModalTrigger title="Edit Post" component={<a className="posts-action-edit"><FormattedMessage id="posts.edit"/></a>}>
+            <Telescope.components.PostsEditForm post={this.props.post}/>
+          </ModalTrigger>
+        </Telescope.components.CanDo>
       </div>
     )
   }

--- a/packages/nova-base-components/lib/posts/PostsNewForm.jsx
+++ b/packages/nova-base-components/lib/posts/PostsNewForm.jsx
@@ -9,7 +9,11 @@ const PostsNewForm = (props, context) => {
   const router = props.router;
 
   return (
-    <Telescope.components.CanCreatePost>
+    <Telescope.components.CanDo
+      action="posts.new"
+      noPermissionMessage="users.cannot_post"
+      displayNoPermissionMessage={true}
+    >
       <div className="posts-new-form">
         <NovaForm 
           collection={Posts} 
@@ -21,7 +25,7 @@ const PostsNewForm = (props, context) => {
           }}
         />
       </div>
-    </Telescope.components.CanCreatePost>
+    </Telescope.components.CanDo>
   )
 }
 

--- a/packages/nova-base-components/lib/users/UsersEdit.jsx
+++ b/packages/nova-base-components/lib/users/UsersEdit.jsx
@@ -13,7 +13,11 @@ const UsersEdit = (props, context) => {
   //const label = `Edit profile for ${Users.getDisplayName(user)}`;
 
   return (
-    <Telescope.components.CanEditUser user={currentUser} userToEdit={user}>
+    <Telescope.components.CanDo 
+      action="users.edit"
+      document={user}
+      displayNoPermissionMessage={true}
+    >
       <div className="page users-edit-form">
         <h2 className="page-title users-edit-form-title"><FormattedMessage id="users.edit_account"/></h2>
         <NovaForm 
@@ -26,7 +30,7 @@ const UsersEdit = (props, context) => {
           }}
         />
       </div>
-    </Telescope.components.CanEditUser>
+    </Telescope.components.CanDo>
   )
 };
 

--- a/packages/nova-i18n-en-us/lib/en_US.js
+++ b/packages/nova-i18n-en-us/lib/en_US.js
@@ -116,6 +116,7 @@ Telescope.strings.en = {
   "app.404": "Sorry, we couldn't find what you were looking for.",
   "app.powered_by": "Powered by Telescope",
   "app.or": "Or",
+  "app.noPermission": "Sorry, you do not have the permission to do this at this time.",
 
   "newsletter": "Newsletter", 
   "newsletter.subscribe": "Subscribe", 


### PR DESCRIPTION
**Goal:** have a generic component to handle permission adapted to the new groups API

**Trigger:** When updating post-by-feed to use the new group API, I realized that I didn't have any check on permission to show or not my components.

**Problem:** Looking at the base components available in `/permissions`, they all do the same kind of things and we repeat the code over and over with just some small variants in 5 components :
- check if the user is logged in or not
- check if the user can perform the action
- display a no permission message

Moreover, in many components, we check permissions like `{Users.canEdit(this.context.currentUser, this.props.post) ? component : ""}` inside render methods.

**Hypothetic solution:** In order to ease the writing of components and handle permissions with more flexibility, I created this `CanDo` component that follows a similar logic.

You supply it an action, a document or not, and a "no permission" message or not, and it takes care of the job for you. I've tried it on the post new form, on the edit action on posts list and on user edit

By now, it's just a draft and a lot of boilerplate. If we go farther in this logic, I think we could use it as a HOC wrapping an exported component : 

```
// MyComponent code
// ...

const permissionsOptions = {
  action: "posts.view.pending.all",
  // ...
};

export default canDo(permissionsOptions)(MyComponent)
```

Feedbacks & discussions really welcomed!