### PR TITLE
Change username to authorName in email template

### DIFF
--- a/packages/nova-email-templates/lib/server/emails/users/accountApproved.handlebars
+++ b/packages/nova-email-templates/lib/server/emails/users/accountApproved.handlebars
@@ -1,3 +1,3 @@
-<span class="heading">{{username}}, welcome to {{siteTitle}}!</span><br><br>
+<span class="heading">{{authorName}}, welcome to {{siteTitle}}!</span><br><br>
 
 You've just been invited. <a href="{{siteUrl}}">Start posting</a>.<br><br>

--- a/packages/nova-email-templates/lib/server/emails/users/newUser.handlebars
+++ b/packages/nova-email-templates/lib/server/emails/users/newUser.handlebars
@@ -1,1 +1,1 @@
-<span class="heading">A new user account has been created: <a href="{{profileUrl}}">{{username}}</a></span><br><br>
+<span class="heading">A new user account has been created: <a href="{{profileUrl}}">{{authorName}}</a></span><br><br>


### PR DESCRIPTION
Social logins might not have a username, but they will always have an
authorName.  This fix changes {{username}} to {{authorName}} in email
templates, avoiding the "new user account: undefined" bug.