### PR TITLE
Corrected imports for debug convenience globals

### DIFF
--- a/packages/nova-debug/lib/globals.js
+++ b/packages/nova-debug/lib/globals.js
@@ -1,6 +1,6 @@
 import PostsImport from "meteor/nova:posts";
-import CommentsImport from "meteor/nova:posts";
-import UsersImport from "meteor/nova:posts";
+import CommentsImport from "meteor/nova:comments";
+import UsersImport from "meteor/nova:users";
 import CategoriesImport from "meteor/nova:categories";
 
 Posts = PostsImport;


### PR DESCRIPTION
When debugging, I wondered why Posts.find().fetch() returned the same as Users.find().fetch() (with both console.table() on the client and meteor shell)

It's because the imports for the Comments, Users and Posts globals were all importing from nova:posts which exports Posts as default.. so they were equal