### PR TITLE
Fix the cancelUpvote to only run once

### DIFF
--- a/packages/nova-voting/lib/vote.js
+++ b/packages/nova-voting/lib/vote.js
@@ -26,7 +26,8 @@ Telescope.operateOnItem = function (collection, itemId, user, operation) {
     !user || 
     !Users.canDo(user, `${item.getCollectionName()}.${operation}`) || 
     operation === "upvote" && hasUpvotedItem ||
-    operation === "downvote" && hasDownvotedItem
+    operation === "downvote" && hasDownvotedItem ||
+    operation === "cancelUpvote" && !hasUpvotedItem
   ) {
     return false; 
   }


### PR DESCRIPTION
Currently you can cancel your upvote many times, this patch fixed the issue on Crater.io