### PR TITLE
Update subscriberIdsToNotify to send unique emails

### DIFF
--- a/packages/nova-subscribe/lib/callbacks.js
+++ b/packages/nova-subscribe/lib/callbacks.js
@@ -90,7 +90,7 @@ if (typeof Package['nova:posts'] !== "undefined") {
 
       if (!!subscribers && !!subscribers.length) {
         // remove userIds of users that have already been notified and of post's author 
-        let subscriberIdsToNotify = _.difference(subscribers, userIdsNotified, [post.userId]);
+        let subscriberIdsToNotify = _.uniq(_.difference(subscribers, userIdsNotified, [post.userId]));
         
         Telescope.notifications.create(subscriberIdsToNotify, 'newPost', notificationData);
 


### PR DESCRIPTION
Added .uniq() for subscribersIdsToNotify in the Categories section to prevent a user from receiving multiple emails if he/she is subscribed to multiple categories.