### PR TITLE
Add Reset Password Feature

### DIFF
--- a/packages/nova-base-components/lib/components.js
+++ b/packages/nova-base-components/lib/components.js
@@ -76,3 +76,4 @@ Telescope.registerComponent("UsersName",            require('./users/UsersName.j
 Telescope.registerComponent("UsersMenu",            require('./users/UsersMenu.jsx'));
 Telescope.registerComponent("UsersAccountMenu",     require('./users/UsersAccountMenu.jsx'));
 Telescope.registerComponent("UsersAccountForm",     require('./users/UsersAccountForm.jsx'));
+Telescope.registerComponent("UsersResetPassword",   require('./users/UsersResetPassword.jsx'));

--- a/packages/nova-base-components/lib/users/UsersResetPassword.jsx
+++ b/packages/nova-base-components/lib/users/UsersResetPassword.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { Accounts, STATES } from 'meteor/std:accounts-ui';
+import { Link } from 'react-router';
 
 class UsersResetPassword extends Component {
   componentDidMount() {
@@ -8,13 +9,28 @@ class UsersResetPassword extends Component {
   }
 
   render() {
+    if (!this.context.currentUser) {
+      return (
+        <Accounts.ui.LoginForm
+          formState={ STATES.PASSWORD_CHANGE }
+        />
+      );
+    }
+
     return (
-      <Accounts.ui.LoginForm
-        formState={ STATES.PASSWORD_CHANGE }
-      />
+      <div className='password-reset-form'>
+        <div>{T9n.get('info.passwordChanged')}!</div>
+        <Link to="/">
+          Return Home
+        </Link>
+      </div>
     );
   }
 }
 
 module.exports = UsersResetPassword;
 export default UsersResetPassword;
+
+UsersResetPassword.contextTypes = {
+  currentUser: React.PropTypes.object
+};

--- a/packages/nova-base-components/lib/users/UsersResetPassword.jsx
+++ b/packages/nova-base-components/lib/users/UsersResetPassword.jsx
@@ -1,0 +1,20 @@
+import React, { Component } from 'react';
+import { Accounts, STATES } from 'meteor/std:accounts-ui';
+
+class UsersResetPassword extends Component {
+  componentDidMount() {
+    const token = this.props.params.token;
+    Accounts._loginButtonsSession.set('resetPasswordToken', token);
+  }
+
+  render() {
+    return (
+      <Accounts.ui.LoginForm
+        formState={ STATES.PASSWORD_CHANGE }
+      />
+    );
+  }
+}
+
+module.exports = UsersResetPassword;
+export default UsersResetPassword;

--- a/packages/nova-base-routes/lib/routes.jsx
+++ b/packages/nova-base-routes/lib/routes.jsx
@@ -17,12 +17,13 @@ Telescope.routes.indexRoute = { name: "posts.list", component: Telescope.compone
 Meteor.startup(() => {
 
   Telescope.routes.add([
-    {name:"posts.daily",    path:"daily",              component:Telescope.components.PostsDaily},
-    {name:"posts.single",   path:"posts/:_id(/:slug)", component:Telescope.components.PostsSingle},
-    {name:"users.single",   path:"users/:slug",        component:Telescope.components.UsersSingle},
-    {name:"users.account",  path:"account",            component:Telescope.components.UsersAccount},
-    {name:"users.edit",     path:"users/:slug/edit",   component:Telescope.components.UsersAccount},
-    {name:"app.notfound",   path:"*",                  component:Telescope.components.Error404},
+    {name:"posts.daily",    path:"daily",                 component:Telescope.components.PostsDaily},
+    {name:"posts.single",   path:"posts/:_id(/:slug)",    component:Telescope.components.PostsSingle},
+    {name:"users.single",   path:"users/:slug",           component:Telescope.components.UsersSingle},
+    {name:"users.account",  path:"account",               component:Telescope.components.UsersAccount},
+    {name:"resetPassword",  path:"reset-password/:token", component:Telescope.components.UsersResetPassword},
+    {name:"users.edit",     path:"users/:slug/edit",      component:Telescope.components.UsersAccount},
+    {name:"app.notfound",   path:"*",                     component:Telescope.components.Error404},
   ]);
 
   const AppRoutes = {

--- a/packages/nova-base-styles/lib/stylesheets/_accounts.scss
+++ b/packages/nova-base-styles/lib/stylesheets/_accounts.scss
@@ -30,3 +30,7 @@
     }
   }
 }
+
+.password-reset-form{
+  text-align: center;
+}

--- a/packages/nova-users/lib/server.js
+++ b/packages/nova-users/lib/server.js
@@ -2,5 +2,6 @@ import Users from './modules.js';
 
 import './server/create_user.js';
 import './server/publications.js';
+import './server/urls.js';
 
 export default Users;

--- a/packages/nova-users/lib/server/urls.js
+++ b/packages/nova-users/lib/server/urls.js
@@ -1,0 +1,1 @@
+Accounts.urls.resetPassword = (token) => Meteor.absoluteUrl(`reset-password/${token}`);


### PR DESCRIPTION
This PR is in response to #1480 

The `componentDidMount` method of `UsersResetPassword` was necessary because [the callback for `Accounts.resetPasswordLink`](https://github.com/studiointeract/accounts-ui/blob/87b4469ae50638f9ca6c33de346141b72cfa585f/imports/login_session.js#L77-L83) was not being called. This is due to the fact that `accounts-base` expects the `reset-password` URL to use query fragments (e.g. `/#/reset-password`) in [attemptToMatchHash](https://github.com/meteor/accounts/blob/77b6084c0bd24129c1e7a6d703d9effddaceadcb/packages/accounts-base/url_client.js#L29-L61). Additionally, we modified the resetPassword URL of accounts-base so that it won't generate links with the query fragment as in [this helpful example](http://stackoverflow.com/questions/26603863/override-reset-password-with-accounts-ui-installed).

Shout outs to @cjlarose for helping me with this weird issue.
