### PR TITLE
default avatar image's URL for ssr

### DIFF
--- a/packages/nova-users/lib/avatar.js
+++ b/packages/nova-users/lib/avatar.js
@@ -21,8 +21,7 @@ Users.avatar = {
     //   'initials' (show the user's initials).
     fallbackType: '',
 
-    // This will replace the included default avatar image's URL
-    // ('packages/utilities_avatar/default.png'). It can be a relative path
+    // Default avatar image's URL. It can be a relative path
     // (relative to website's base URL, e.g. 'images/defaultthis.png').
     defaultImageUrl: 'https://placekitten.com/80/80',
 
@@ -167,13 +166,13 @@ Users.avatar = {
         url = this.getCustomUrl(user);
       }
       else if (svc === 'none') {
-        defaultUrl = this.options.defaultImageUrl || '/packages/utilities_avatar/default.png';
+        defaultUrl = this.options.defaultImageUrl;
         // If it's a relative path (no '//' anywhere), complete the URL
         if (defaultUrl.indexOf('//') === -1) {
-          // Add starting slash if it does not exist
-          if (defaultUrl.charAt(0) !== '/') defaultUrl = '/' + defaultUrl;
+          // remove starting slash if it exists
+          if (defaultUrl.charAt(0) === '/') defaultUrl = defaultUrl.substr(1);
           // Then add the relative path to the server's base URL
-          defaultUrl = [window.location.origin, defaultUrl].join('');
+          defaultUrl = Meteor.absoluteUrl(defaultUrl);
         }
         url = this.getGravatarUrl(user, defaultUrl);
       }


### PR DESCRIPTION
two things

1. forgot utilities_avatar
2. change `window.location.origin` to use `Meteor.absoluteUrl` method, for ssr

so if someone set default avatar url to e.g. `image/xxx.jpg`
and server wont alert `'ReferenceError: window is not defined`.

:) 👍 