### PR TITLE
Allow redux middleware extensions

### DIFF
--- a/packages/nova-core/lib/modules.js
+++ b/packages/nova-core/lib/modules.js
@@ -1,6 +1,6 @@
 // import and re-export
-import { Components, registerComponent, replaceComponent, getRawComponent, getComponent, copyHoCs, createCollection, Callbacks, addCallback, removeCallback, runCallbacks, runCallbacksAsync, GraphQLSchema, Routes, addRoute, Utils, getSetting, Strings, addStrings, Actions, Reducers, Headtags } from 'meteor/nova:lib';
-export { Components, registerComponent, replaceComponent, getRawComponent, getComponent, copyHoCs, createCollection, Callbacks, addCallback, removeCallback, runCallbacks, runCallbacksAsync, GraphQLSchema, Routes, addRoute, Utils, getSetting, Strings, addStrings, Actions, Reducers, Headtags };
+import { Components, registerComponent, replaceComponent, getRawComponent, getComponent, copyHoCs, createCollection, Callbacks, addCallback, removeCallback, runCallbacks, runCallbacksAsync, GraphQLSchema, Routes, addRoute, Utils, getSetting, Strings, addStrings, Actions, Reducers, Middleware, Headtags } from 'meteor/nova:lib';
+export { Components, registerComponent, replaceComponent, getRawComponent, getComponent, copyHoCs, createCollection, Callbacks, addCallback, removeCallback, runCallbacks, runCallbacksAsync, GraphQLSchema, Routes, addRoute, Utils, getSetting, Strings, addStrings, Actions, Reducers, Middleware, Headtags };
 
 export { default as App } from "./components/App.jsx";
 export { default as Layout } from "./components/Layout.jsx";

--- a/packages/nova-lib/lib/modules.js
+++ b/packages/nova-lib/lib/modules.js
@@ -18,7 +18,7 @@ export { Routes, addRoute } from './routes.js';
 export { Utils } from './utils.js';
 export { getSetting } from './settings.js';
 export { Strings, addStrings } from './strings.js';
-export { Actions, Reducers } from './redux.js';
+export { Actions, Reducers, Middleware } from './redux.js';
 export { Headtags } from './headtags.js';
 
 export default Telescope;

--- a/packages/nova-lib/lib/redux.js
+++ b/packages/nova-lib/lib/redux.js
@@ -1,2 +1,3 @@
 export const Actions = {};
 export const Reducers = {};
+export const Middleware = {};

--- a/packages/nova-lib/lib/redux.js
+++ b/packages/nova-lib/lib/redux.js
@@ -1,3 +1,3 @@
 export const Actions = {};
 export const Reducers = {};
-export const Middleware = {};
+export const Middleware = [];

--- a/packages/nova-routing/lib/store.js
+++ b/packages/nova-routing/lib/store.js
@@ -1,7 +1,7 @@
 import { createStore, combineReducers, applyMiddleware, compose } from 'redux';
 // import { routerMiddleware } from 'react-router-redux'
 
-import { Reducers }from 'meteor/nova:lib';
+import { Reducers, Middleware }from 'meteor/nova:lib';
 
 const configureStore = (client, initialState = {}, history) => createStore(
   // reducers
@@ -10,7 +10,7 @@ const configureStore = (client, initialState = {}, history) => createStore(
   initialState,
   // middlewares
   compose(
-    applyMiddleware(client.middleware()/*, routerMiddleware(history)*/),
+    applyMiddleware(...Middleware, client.middleware()/*, routerMiddleware(history)*/),
     typeof window !== "undefined" && window.devToolsExtension ? window.devToolsExtension() : f => f
   ),
 );

--- a/packages/nova-routing/lib/store.js
+++ b/packages/nova-routing/lib/store.js
@@ -1,7 +1,5 @@
 import { createStore, combineReducers, applyMiddleware, compose } from 'redux';
-// import { routerMiddleware } from 'react-router-redux'
-
-import { Reducers, Middleware }from 'meteor/nova:lib';
+import { Reducers, Middleware }from 'meteor/nova:core';
 
 const configureStore = (client, initialState = {}, history) => createStore(
   // reducers


### PR DESCRIPTION
Integrating a REST api into the redux store. The reducers and actions are easy to extend, but I need to add redux-thunk into the middleware stack, hence the PR.