### PR TITLE
using nova:forms shows issues when being imported

### DIFF
--- a/packages/nova-forms/package.js
+++ b/packages/nova-forms/package.js
@@ -27,3 +27,13 @@ Package.onUse(function(api) {
   api.mainModule("lib/export.js", ["client", "server"]);
 
 });
+
+Package.onTest(function(api) {
+  api.use([
+    'ecmascript',
+    'tinytest',
+    'nova:forms'
+  ]);
+
+  api.mainModule('test.js');
+});

--- a/packages/nova-forms/package.js
+++ b/packages/nova-forms/package.js
@@ -17,7 +17,7 @@ Package.onUse(function(api) {
     'check',
     'aldeed:simple-schema@1.5.3',
     'aldeed:collection2@2.8.0',
-    'fourseven:scss'
+    'fourseven:scss@3.8.0'
   ]);
 
   api.addFiles([

--- a/packages/nova-forms/test.js
+++ b/packages/nova-forms/test.js
@@ -1,0 +1,7 @@
+import { Tinytest } from "meteor/tinytest";
+import FormWrapper from 'meteor/nova:forms';
+
+Tinytest.add('nova:forms - initialize', function (test) {
+    // because of compose()
+    test.equal('GraphQL', FormWrapper.name);
+});


### PR DESCRIPTION
When trying to use `nova:forms` directly, or any `nova:`* package that depends on `nova:forms`, this issue is encountered.

```
=> Started proxy.
=> Started MongoDB.
=> Errors prevented startup:

   While loading package fourseven:scss@0.9.6:
```

Looking into `fourseven:scss`' [Compatibilty list](https://atmospherejs.com/fourseven/scss) :
```
Meteor Version  Recommended
1.0 - 1.1       3.2.0
1.2 - 1.3.1     3.4.2
1.3.2+          3.8.0
1.4.0           3.8.1
1.4.1+          3.13.0
```

`nova:forms` currently depend on `Meteor 1.3` so `3.8.0` is used.

This appends the `@3.8.0` on `fourseven:scss` and allows the package to be imported.

Package can be validated by running `meteor test-packages nova:forms`.
