### PR TITLE
Added test for nova:posts

### DIFF
--- a/packages/nova-posts/package.js
+++ b/packages/nova-posts/package.js
@@ -11,6 +11,7 @@ Package.onUse(function (api) {
 
   api.use([
     'nova:core@1.0.0',
+    'nova:events@1.0.0',
     'nova:users@1.0.0',
     'utilities:react-list-container@0.1.10'
   ]);
@@ -23,4 +24,15 @@ Package.onUse(function (api) {
   api.mainModule("lib/server.js", "server");
   api.mainModule("lib/client.js", "client");
 
+});
+
+
+Package.onTest(function(api) {
+  api.use([
+    'ecmascript',
+    'tinytest',
+    'nova:posts',
+  ]);
+  
+  api.mainModule('test.js');
 });

--- a/packages/nova-posts/test.js
+++ b/packages/nova-posts/test.js
@@ -1,0 +1,6 @@
+import { Tinytest } from "meteor/tinytest";
+import Posts from 'meteor/nova:posts';
+
+Tinytest.add('nova:posts - initialize', function (test) {
+    test.isNotNull(Posts);
+});


### PR DESCRIPTION
When trying to import package, import fails because of missing dependency on `nova:events`

```
meteor test-packages nova:posts
[[[[[ Tests ]]]]]

=> Started proxy.
=> Started MongoDB.
~/.meteor/packages/meteor-tool/.1.4.2_3.1rd9djy++os.osx.x86_64+web.browser+web.cordova/mt-os.osx.x86_64/dev_bundle/server-lib/node_modules/fibers/future.js:280
                        throw(ex);
                        ^

Error: Can't find npm module 'meteor/nova:events'. Did you forget to call 'Npm.depends' in package.js within the 'modules-runtime' package?
...snip...
=> Exited with code: 1
```

Adding `nova:events@1.0.0` to Package dependency resolves this issue.

To validate, comment out the import for `nova:events`.
This will halt the test and fail.