### PR TITLE
add explicit control for clearing out form fields

### DIFF
--- a/packages/nova-forms/lib/DateTime.jsx
+++ b/packages/nova-forms/lib/DateTime.jsx
@@ -12,11 +12,12 @@ class DateTime extends Component {
 
   // when the datetime picker has mounted, SmartForm will catch the date value (no formsy mixin in this component)
   componentDidMount() {
-    this.updateDate(this.props.value || new Date());
+    this.updateDate(this.props.value || new Date(), true);
   }
 
-  updateDate(date) {
-    this.context.updateCurrentValues({[this.props.name]: date});
+  updateDate(date, isDefault=false) {
+    // this.context.updateCurrentValues({[this.props.name]: date});
+    this.props.onChange(this.props.name, date, isDefault);
   }
 
   render() {
@@ -25,7 +26,7 @@ class DateTime extends Component {
         <label className="control-label col-sm-3">{this.props.label}</label>
         <div className="col-sm-9">
           <DateTimePicker
-            value={this.props.value || new Date()}
+            value={this.props.value}
             // newDate argument is a Moment object given by react-datetime
             onChange={newDate => this.updateDate(newDate._d)}
             format={"x"}

--- a/packages/nova-forms/lib/Form.jsx
+++ b/packages/nova-forms/lib/Form.jsx
@@ -65,15 +65,14 @@ class Form extends Component {
     this.deleteDocument = this.deleteDocument.bind(this);
     // a debounced version of seState that only updates state every 500 ms (not used)
     this.debouncedSetState = _.debounce(this.setState, 500);
-    this.clearField = this.clearField.bind(this);
-    this.unclearField = this.unclearField.bind(this);
+    // this.clearField = this.clearField.bind(this);
+    // this.unclearField = this.unclearField.bind(this);
 
     this.state = {
       disabled: false,
       errors: [],
       autofilledValues: (props.formType === 'new' && props.prefilledProps) || {},
       currentValues: {},
-      clearedFields: []
     };
   }
 
@@ -259,6 +258,14 @@ class Form extends Component {
 
   // manually update the current values of one or more fields(i.e. on blur). See above for on change instead
   updateCurrentValues(newValues) {
+    // gets form field's name which is changed by user
+    // const [fieldName] = _.isObject(Object) ? Object.keys(newValues) : [];
+    // if fieldName is not empty
+    // if(fieldName){
+      // remove from clearedFields
+      // this.unclearField(fieldName);
+    // };
+    
     // keep the previous ones and extend (with possible replacement) with new ones
     this.setState(prevState => ({
       currentValues: {
@@ -337,21 +344,21 @@ class Form extends Component {
     }));
   }
   
-  // add to cleared fields
+/*  // add to cleared fields
   clearField(fieldName){
     this.setState({
-      deletedFields: [...this.deletedFields, fieldName]
+      clearedFields: [...this.state.clearedFields, fieldName]
     });
     
-    return () => this.removeFromDeletedfields(fieldName);
+    return () => this.unclearField(fieldName);
   }
 
   // remove from cleared fields
-  unclearfield(fieldName){ 
+  unclearField(fieldName){ 
     this.setState({
-       deletedFields: this.deletedFields.filter( name => name != fieldName)
+       clearedFields: this.state.clearedFields.filter( name => name != fieldName)
       });
-  }
+  }*/
 
   // add something to prefilled values
   addToAutofilledValues(property) {
@@ -463,7 +470,8 @@ class Form extends Component {
       const set = _.compactObject(flatten(data));
 
       // put all keys without data on $unset
-      const unsetKeys = _.difference(fields, _.keys(set)).concat(this.state.deletedFields);
+      const unsetKeys = _.difference(fields, _.keys(set));
+      // .concat(this.state.clearedFields);
       const unset = _.object(unsetKeys, unsetKeys.map(()=>true));
 
       // build modifier
@@ -511,9 +519,6 @@ class Form extends Component {
           onKeyDown={this.formKeyDown}
           disabled={this.state.disabled}
           ref="form"
-          clearField={this.clearField}
-          unclearField={this.unclearField}
-          clearedFields={this.state.clearedFields}
         >
           {this.renderErrors()}
           {fieldGroups.map(group => <FormGroup key={group.name} {...group} updateCurrentValues={this.updateCurrentValues} />)}

--- a/packages/nova-forms/lib/FormComponent.jsx
+++ b/packages/nova-forms/lib/FormComponent.jsx
@@ -17,13 +17,27 @@ class FormComponent extends Component {
 
   constructor(props) {
     super(props);
-    this.handleBlur = this.handleBlur.bind(this);
+    this.state = {
+      isDirty: false
+    };
+    // this.handleBlur = this.handleBlur.bind(this);
+    this.onChange = this.onChange.bind(this);
   }
 
-  handleBlur() {
+  onChange(name, value, isDefault=false) {
     // see https://facebook.github.io/react/docs/more-about-refs.html
     if (this.formControl !== null) {
-      this.props.updateCurrentValues({[this.props.name]: this.formControl.getValue()});
+      this.updateCurrentValue(value, isDefault);
+    }
+  }
+  
+  updateCurrentValue(value, isDefault=false){
+    console.log(value, isDefault)
+    this.props.updateCurrentValues({[this.props.name]: value});
+    if(!isDefault){
+      this.setState({
+        isDirty: true
+      });
     }
   }
 
@@ -33,12 +47,14 @@ class FormComponent extends Component {
     const { control, group, updateCurrentValues, document, beforeComponent, afterComponent, ...rest } = this.props; // eslint-disable-line
 
     const base = this.props.control === "function" ? this.props : rest;
-
+    
     const properties = {
       ...base,
-      onBlur: this.handleBlur,
+      onChange: this.onChange,
       ref: (ref) => this.formControl = ref
     };
+
+    delete properties.clearField;
 
     // if control is a React component, use it
     if (typeof this.props.control === "function") {
@@ -67,20 +83,43 @@ class FormComponent extends Component {
         default:
           return <Input         {...properties} type="text" />;
       }
-
+    }
+  }
+  
+  clear(){
+    this.updateCurrentValue(this.props.prefilledValue);
+    this.setState({
+      isDirty: false
+    });
+  }
+  
+  addClearButton(){
+    const style = {
+      position: "absolute",
+      left: "calc(25% - 10px)",
+      top: "13px",
+      cursor: "hnad",
+      cursor: "pointer",
+      zIndex: 100
+    };
+    
+    switch (this.props.control) {
+      case "select":
+      case "datetime":
+        return this.state.isDirty ? <i style={style} onClick={e => this.clear()} className="icon fa fa-fw fa-times icon-close field-clear-button"></i> : "";
     }
   }
 
   render() {
     return (
-      <div className={"input-"+this.props.name}>
+      <div style={{position: "relative"}} className={"input-"+this.props.name}>
         {this.props.beforeComponent ? this.props.beforeComponent : null}
+        {this.addClearButton()}
         {this.renderComponent()}
         {this.props.afterComponent ? this.props.afterComponent : null}
       </div>
-    )
+    );
   }
-
 }
 
 FormComponent.propTypes = {


### PR DESCRIPTION
- create clearField(fieldName) method on Form.jsx. clearField should add form name to a new this.state.deletedFields array

- create unclearField(fieldName) method (find better name?) that removes field from the deletedFields array 

- pass "clearField" callback from Form.jsx down to the form component

- if a field value is modified after it has been cleared, unclearField should be called to remove the field name should be removed from deletedFields

- modify the submitForm method in Form.jsx to also add all deletedFields fields to the unset object