### PR TITLE
Fixed out-of-the-box newsletter config settings that causes constant …

### DIFF
--- a/sample_settings.json
+++ b/sample_settings.json
@@ -23,7 +23,7 @@
 
     "language": "en",
     "locale": "en",
-    
+
     "twitterAccount": "foo",
     "facebookPage": "http://facebook.com/foo",
 
@@ -39,7 +39,8 @@
   "embedlyKey":"123foo",
   "mailChimpAPIKey": "123foo",
   "mailChimpListId": "123foo",
-
+  "newsletterFrequency": [1,2,3,4,5,6,7],
+  "newsletterTime": "14:20",
   "newsletterExcerptLength": 20,
   "postExcerptLength": 30,
 


### PR DESCRIPTION
…attempts at newsletter scheduling:

I20170310-12:39:00.669(-5) (percolatestudio_synced-cron.js:84) SyncedCron: Starting "scheduleNewsletter".
I20170310-12:39:00.674(-5) (percolatestudio_synced-cron.js:84) SyncedCron: Finished "scheduleNewsletter".